### PR TITLE
Reduce wasm worker logs, build warnings, and dead variables. Improve Chainsig demo logs and toasts.

### DIFF
--- a/examples/relay-cloudflare-worker/src/worker.ts
+++ b/examples/relay-cloudflare-worker/src/worker.ts
@@ -44,8 +44,8 @@ function getService(env: Env) {
       webAuthnContractId: env.WEBAUTHN_CONTRACT_ID,
       nearRpcUrl: env.NEAR_RPC_URL,
       networkId: env.NETWORK_ID || 'testnet',
-      accountInitialBalance: env.ACCOUNT_INITIAL_BALANCE || '30000000000000000000000',
-      createAccountAndRegisterGas: env.CREATE_ACCOUNT_AND_REGISTER_GAS || '85000000000000',
+      accountInitialBalance: env.ACCOUNT_INITIAL_BALANCE || '40000000000000000000000', // 0.04 NEAR
+      createAccountAndRegisterGas: env.CREATE_ACCOUNT_AND_REGISTER_GAS || '85000000000000', // 85 TGas (tested)
       shamir: {
         shamir_p_b64u: env.SHAMIR_P_B64U,
         shamir_e_s_b64u: env.SHAMIR_E_S_B64U,

--- a/examples/relay-server/src/index.ts
+++ b/examples/relay-server/src/index.ts
@@ -34,8 +34,8 @@ const authService = new AuthService({
   // Prefer env override; default to FastNEAR which is often more reliable for tests
   nearRpcUrl: process.env.NEAR_RPC_URL || 'https://test.rpc.fastnear.com',
   networkId: 'testnet',
-  accountInitialBalance: '30000000000000000000000', // 0.03 NEAR
-  createAccountAndRegisterGas: '85000000000000', // 80 TGas (tested)
+  accountInitialBalance: '40000000000000000000000', // 0.04 NEAR
+  createAccountAndRegisterGas: '85000000000000', // 85 TGas (tested)
   // Shamir 3-pass params (base64url bigints)
   shamir: {
     shamir_p_b64u: process.env.SHAMIR_P_B64U!,

--- a/examples/tatchi-docs/src/components/DemoChainsigs/FaucetLinksRow.tsx
+++ b/examples/tatchi-docs/src/components/DemoChainsigs/FaucetLinksRow.tsx
@@ -170,7 +170,7 @@ export const FaucetLinksRow: React.FC<FaucetLinksRowProps> = ({ chainId, address
           <div className={`faucet-warning ${wantsUsdc ? 'faucet-anim-show' : ''}`} style={{ marginTop: '0.5rem' }}>
             Fund your address with test USDC
             <br/>
-            <a href="https://faucet.circle.com/" target="_blank" rel="noreferrer noopener">Circle USDC faucet</a>
+            <a href="https://faucet.circle.com/" target="_blank" rel="noreferrer noopener">Circle USDC faucet (choose Eth Sepolia)</a>
           </div>
         )}
       </div>

--- a/examples/tatchi-docs/src/components/DemoChainsigs/hooks/helpers/near.ts
+++ b/examples/tatchi-docs/src/components/DemoChainsigs/hooks/helpers/near.ts
@@ -36,6 +36,118 @@ export function extractNearSuccessValue(result: unknown): string | null {
   return null;
 }
 
+/**
+ * Attempt to extract a human‑readable failure from a NEAR execution outcome
+ * or an RPC error object returned by the provider.
+ */
+export function toUserFriendlyNearErrorFromOutcome(
+  result: unknown
+): { title: string; description?: string } | null {
+  try {
+    const fmtYocto = (yocto: string): string => {
+      // format yoctoNEAR (1e-24) to NEAR with up to 5 decimals
+      try {
+        const NEG = yocto.startsWith('-');
+        const s = NEG ? yocto.slice(1) : yocto;
+        if (!/^[0-9]+$/.test(s)) return yocto;
+        const pad = s.padStart(25, '0');
+        const whole = pad.slice(0, -24).replace(/^0+/, '') || '0';
+        let frac = pad.slice(-24).replace(/0+$/, '');
+        if (frac.length > 5) frac = frac.slice(0, 5).replace(/0+$/, '');
+        const out = frac ? `${whole}.${frac}` : whole;
+        return NEG ? `-${out}` : out;
+      } catch {
+        return yocto;
+      }
+    };
+
+    const pickFailure = (container: any): any | undefined => {
+      if (!container || typeof container !== 'object') return undefined;
+      const status = container.status ?? container?.outcome?.status;
+      if (status && typeof status === 'object' && 'Failure' in status) return (status as any).Failure;
+      return undefined;
+    };
+
+    // 1) Try FinalExecutionOutcome‑like shape
+    if (isRecord(result)) {
+      const resObj: any = result;
+      const top = isRecord(resObj.result) ? (resObj.result as any) : resObj;
+      let failure = pickFailure(top);
+      if (!failure && Array.isArray(top?.receipts_outcome)) {
+        for (const r of top.receipts_outcome) {
+          failure = pickFailure(r);
+          if (failure) break;
+        }
+      }
+
+      if (failure) {
+        // InvalidTxError.NotEnoughBalance
+        const notEnough = failure?.InvalidTxError?.NotEnoughBalance
+          || failure?.NotEnoughBalance
+          || failure?.ActionError?.kind?.NotEnoughBalance; // various shapes
+        if (notEnough && typeof notEnough === 'object') {
+          const balance = String((notEnough as any).balance ?? '0');
+          const cost = String((notEnough as any).cost ?? '0');
+          const haveNear = fmtYocto(balance);
+          const needNear = fmtYocto(cost);
+          return {
+            title: 'NotEnoughBalance',
+            description: `balance: ${balance} (≈ ${haveNear} NEAR), cost: ${cost} (≈ ${needNear} NEAR)`,
+          };
+        }
+
+        // FunctionCallError.ExecutionError message
+        const execErr = failure?.ActionError?.kind?.FunctionCallError?.ExecutionError;
+        if (typeof execErr === 'string') {
+          return { title: 'Contract execution failed.', description: execErr };
+        }
+
+        // Fallback to JSON of failure kind
+        const kind = failure?.ActionError?.kind || failure?.InvalidTxError || failure?.TxExecutionError || failure;
+        return { title: 'Transaction failed on NEAR.', description: JSON.stringify(kind) };
+      }
+
+    // 2) Try RPC error passthrough shape (name/cause/data)
+    //    Prefer structured details returned by SDK ActionResult.errorDetails
+    const err = (resObj as any).errorDetails ?? (resObj as any).error;
+    if (isRecord(err)) {
+      // NotEnoughBalance under data.TxExecutionError.InvalidTxError.NotEnoughBalance
+      const ne = (err as any)?.data?.TxExecutionError?.InvalidTxError?.NotEnoughBalance;
+      if (ne && typeof ne === 'object') {
+        const balance = String((ne as any).balance ?? '0');
+        const cost = String((ne as any).cost ?? '0');
+        return {
+          title: 'NotEnoughBalance',
+          description: `balance: ${balance} (≈ ${fmtYocto(balance)} NEAR), cost: ${cost} (≈ ${fmtYocto(cost)} NEAR)`,
+        };
+      }
+      // Some providers use data.Failure
+      const ne2 = (err as any)?.data?.Failure?.NotEnoughBalance
+        || (err as any)?.data?.Failure?.InvalidTxError?.NotEnoughBalance;
+      if (ne2 && typeof ne2 === 'object') {
+        const balance = String((ne2 as any).balance ?? '0');
+        const cost = String((ne2 as any).cost ?? '0');
+        return {
+          title: 'NotEnoughBalance',
+          description: `balance: ${balance} (≈ ${fmtYocto(balance)} NEAR), cost: ${cost} (≈ ${fmtYocto(cost)} NEAR)`,
+        };
+      }
+      const name = (err as any).name || (err as any).code || 'NEAR RPC error';
+      return { title: String(name), description: JSON.stringify(err) };
+    }
+    // If errorDetails was a string, surface it directly
+    if (typeof ((resObj as any).errorDetails) === 'string') {
+      const s = String((resObj as any).errorDetails);
+      if (/NotEnoughBalance/i.test(s)) {
+        return { title: 'Not enough NEAR to cover transaction cost.', description: s };
+      }
+      return { title: 'NEAR RPC error', description: s };
+    }
+  }
+  } catch {}
+  return null;
+}
+
 export function base64ToBytes(b64: string): Uint8Array {
   if (typeof atob === 'function') {
     const bin = atob(b64);
@@ -60,4 +172,3 @@ export function decodeMpcRsvFromSuccessValue(successValueB64: string): RSVSignat
 export function renderExplorerLink(url: string): React.ReactElement {
   return React.createElement('a', { href: url, target: '_blank', rel: 'noreferrer' }, 'View on explorer');
 }
-

--- a/examples/tatchi-docs/src/components/DemoChainsigs/index.tsx
+++ b/examples/tatchi-docs/src/components/DemoChainsigs/index.tsx
@@ -43,7 +43,6 @@ export const DemoChainsigs: React.FC = () => {
   // MPC parameters
   const [mpcContractId, setMpcContractId] = useState<string>('');
   const [path] = useState<string>('ethereum-1');
-  // key version not needed in current adapter calls
 
   const chainIdNum = useMemo(() => {
     const n = Number((chainId || '').trim() || '11155111');
@@ -153,9 +152,9 @@ export const DemoChainsigs: React.FC = () => {
             <div className="demo-subtitle">
               Send NEAR Intents using TouchID
             </div>
-            Request a Chain Signature from NEAR intents contract,
-            then broadcast it to the Ethereum Sepolia network,
-            or any network supported by NEAR intents such as Solana, Bitcoin, Zcash, etc.
+            Request a Chain Signature from the NEAR intents contract.
+            Then send it to Ethereum, or any network supported by NEAR intents
+            such as Solana, Bitcoin, Zcash, etc.
           </div>
 
           <div className="input-group"

--- a/examples/tatchi-docs/src/components/DemoPage.tsx
+++ b/examples/tatchi-docs/src/components/DemoPage.tsx
@@ -485,11 +485,10 @@ export const DemoPage: React.FC = () => {
         </div>
 
         <div className="action-section" style={{ marginTop: '1rem' }}>
-          <h2 className="demo-subtitle">Choose between Modal or Drawer</h2>
+          <h2 className="demo-subtitle">Configure Transaction UX Options</h2>
           <div className="action-text">
             Choose between Modal or Drawer for the tx confirmer menus.
-            <br/>
-            You can also skip the confirmation menu (on desktop).
+            You can also skip the confirmation menu.
           </div>
           <div style={{ display: 'flex', gap: 12 }}>
             <LoadingButton

--- a/examples/tatchi-docs/src/components/PasskeyLoginMenu.tsx
+++ b/examples/tatchi-docs/src/components/PasskeyLoginMenu.tsx
@@ -213,6 +213,12 @@ export function PasskeyLoginMenu(props: { onLoggedIn?: (nearAccountId?: string) 
         defaultMode={authMenuControl.defaultModeOverride ?? (accountExists ? AuthMenuMode.Login : AuthMenuMode.Register)}
         onLogin={onLogin}
         loadingScreenDelayMs={0}
+        headings={{
+          registration: {
+            title: 'Register Account',
+            subtitle: 'Demo: Create a wallet with Passkey',
+          },
+        }}
         onRegister={onRegister}
         onRecoverAccount={onRecover}
         linkDeviceOptions={{

--- a/examples/tatchi-docs/src/components/Toaster.css
+++ b/examples/tatchi-docs/src/components/Toaster.css
@@ -73,16 +73,14 @@
 }
 
 [data-sonner-toaster][data-theme] [data-sonner-toast] [data-close-button] {
-  /* Neutralize default absolute placement and make it a flex item at the end */
-  position: static !important;
-  top: auto !important;
-  right: auto !important;
+  /* Position the close button at the toast's top-right corner */
+  position: absolute !important;
+  top: -0.25rem !important;
+  right: -0.25rem !important;
   left: auto !important;
   transform: none !important;
-  order: 999 !important;              /* ensure it renders after content */
-  margin-inline-start: auto !important;/* push to end in LTR/RTL */
 
-  /* Center the icon and remove global padding */
+  /* Tight icon button without extra padding */
   padding: 0 !important;
   width: 20px;
   height: 20px;

--- a/sdk/src/core/PasskeyManager/actions.ts
+++ b/sdk/src/core/PasskeyManager/actions.ts
@@ -352,7 +352,13 @@ export async function executeActionInternal({
       message: `Action failed: ${short || e.message}`,
       error: short || e.message
     });
-    const result: ActionResult = { success: false, error: e.message, transactionId: undefined };
+    const result: ActionResult = {
+      success: false,
+      error: e.message,
+      // propagate structured RPC details when present so UIs can render helpful errors
+      errorDetails: (e as any)?.details,
+      transactionId: undefined,
+    };
     afterCall?.(false);
     return result;
   }

--- a/sdk/src/core/PasskeyManager/registration.ts
+++ b/sdk/src/core/PasskeyManager/registration.ts
@@ -466,7 +466,7 @@ const validateRegistrationInputs = async (
   } catch (viewError: any) {
     // If viewAccount throws any error, assume the account doesn't exist
     // This is more reliable than parsing specific error formats that vary between RPC servers
-    console.log(`Account ${nearAccountId} is available for registration (${viewError.message})`);
+    console.debug(`Account ${nearAccountId} is available for registration (${viewError.message})`);
     onEvent?.({
       step: 1,
       phase: RegistrationPhase.STEP_1_WEBAUTHN_VERIFICATION,

--- a/sdk/src/core/types/passkeyManager.ts
+++ b/sdk/src/core/types/passkeyManager.ts
@@ -616,6 +616,8 @@ export interface LoginResult {
 export interface ActionResult {
   success: boolean;
   error?: string;
+  // Optional structured error details when available (e.g., NEAR RPC error payload)
+  errorDetails?: unknown;
   transactionId?: string;
   result?: FinalExecutionOutcome;
 }

--- a/sdk/src/react/components/PasskeyAuthMenu/index.tsx
+++ b/sdk/src/react/components/PasskeyAuthMenu/index.tsx
@@ -16,10 +16,11 @@ import {
   AuthMenuMode,
   AuthMenuModeMap,
   type AuthMenuModeLabel,
+  type AuthMenuHeadings,
 } from './types';
 
 export { AuthMenuMode, AuthMenuModeMap };
-export type { AuthMenuModeLabel };
+export type { AuthMenuModeLabel, AuthMenuHeadings };
 
 export interface PasskeyAuthMenuProps {
   onLogin?: () => void;
@@ -43,6 +44,8 @@ export interface PasskeyAuthMenuProps {
   defaultMode?: AuthMenuMode;
   style?: React.CSSProperties;
   className?: string;
+  /** Optional custom headings for each mode */
+  headings?: AuthMenuHeadings;
   /**
    * Optional social login hooks. Provide a function per provider that returns
    * the derived username (e.g., email/handle) after the external auth flow.
@@ -78,6 +81,7 @@ const PasskeyAuthMenuInner: React.FC<PasskeyAuthMenuProps> = ({
   // login options
   socialLogin,
   loadingScreenDelayMs,
+  headings,
 }) => {
 
   const { tokens, isDark } = useTheme();
@@ -110,6 +114,7 @@ const PasskeyAuthMenuInner: React.FC<PasskeyAuthMenuProps> = ({
     passkeyManager,
     currentValue,
     setCurrentValue,
+    headings,
   });
 
   const { canShowContinue, canSubmit } = useProceedEligibility({

--- a/sdk/src/react/components/PasskeyAuthMenu/types.ts
+++ b/sdk/src/react/components/PasskeyAuthMenu/types.ts
@@ -16,3 +16,13 @@ export interface AuthMenuTitle {
   title: string;
   subtitle: string;
 }
+
+/** Optional custom headings per mode */
+export interface AuthMenuHeadings {
+  /** Headings for the Register mode */
+  registration?: AuthMenuTitle;
+  /** Headings for the Login mode */
+  login?: AuthMenuTitle;
+  /** Headings for the Recover Account mode */
+  recoverAccount?: AuthMenuTitle;
+}

--- a/sdk/src/react/index.ts
+++ b/sdk/src/react/index.ts
@@ -111,7 +111,7 @@ export {
 // Sign Up / Sign In menu
 export { PasskeyAuthMenu } from './components/PasskeyAuthMenu';
 export { AuthMenuMode, AuthMenuModeMap } from './components/PasskeyAuthMenu';
-export type { AuthMenuModeLabel } from './components/PasskeyAuthMenu';
+export type { AuthMenuModeLabel, AuthMenuHeadings } from './components/PasskeyAuthMenu';
 // Small SVG utility icon used in examples
 export { default as TouchIcon } from './components/ProfileSettingsButton/icons/TouchIcon';
 export { default as QRCodeIcon } from './components/QRCodeIcon';

--- a/sdk/src/wasm_signer_worker/src/actions.rs
+++ b/sdk/src/wasm_signer_worker/src/actions.rs
@@ -397,7 +397,6 @@ pub fn get_action_handler(params: &ActionParams) -> Result<Box<dyn ActionHandler
         ActionParams::AddKey { .. } => Ok(Box::new(AddKeyActionHandler)),
         ActionParams::DeleteKey { .. } => Ok(Box::new(DeleteKeyActionHandler)),
         ActionParams::DeleteAccount { .. } => Ok(Box::new(DeleteAccountActionHandler)),
-        _ => Err("Unsupported action type".to_string()),
     }
 }
 

--- a/sdk/src/wasm_signer_worker/src/config.rs
+++ b/sdk/src/wasm_signer_worker/src/config.rs
@@ -25,6 +25,7 @@ pub const ED25519_HKDF_KEY_INFO: &str = "ed25519-signing-key-dual-prf-v1";
 // === GAS CONSTANTS ===
 
 /// Standard gas amount for contract verification calls (30 TGas)
+#[allow(dead_code)]
 pub const VERIFY_REGISTRATION_GAS: &str = "30000000000000";
 
 /// Higher gas amount for device linking registration calls (30 TGas)

--- a/sdk/src/wasm_signer_worker/src/handlers/handle_decrypt_private_key_with_prf.rs
+++ b/sdk/src/wasm_signer_worker/src/handlers/handle_decrypt_private_key_with_prf.rs
@@ -5,7 +5,6 @@
 // ******************************************************************************
 use crate::handlers::confirm_tx_details::{generate_request_id, ConfirmationResult};
 use bs58;
-use log::info;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -104,8 +103,6 @@ pub async fn handle_decrypt_private_key_with_prf(
 
     let private_key_near_format =
         format!("ed25519:{}", bs58::encode(&full_private_key).into_string());
-
-    info!("RUST: Private key decrypted successfully with structured types");
 
     let result =
         DecryptPrivateKeyResult::new(private_key_near_format, request.near_account_id.clone());

--- a/sdk/src/wasm_signer_worker/src/handlers/handle_derive_near_keypair_and_encrypt.rs
+++ b/sdk/src/wasm_signer_worker/src/handlers/handle_derive_near_keypair_and_encrypt.rs
@@ -5,7 +5,7 @@
 // ******************************************************************************
 
 use bs58;
-use log::info;
+use log::{debug, warn};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use wasm_bindgen::prelude::*;
@@ -113,7 +113,7 @@ impl DeriveNearKeypairAndEncryptResult {
 pub async fn handle_derive_near_keypair_and_encrypt(
     request: DeriveNearKeypairAndEncryptRequest,
 ) -> Result<DeriveNearKeypairAndEncryptResult, String> {
-    info!("RUST: WASM binding - starting structured dual PRF keypair derivation with optional transaction signing");
+    debug!("[rust wasm]: starting dual PRF keypair derivation with optional transaction signing");
     // Convert wasm-bindgen types to internal types
     let internal_dual_prf_outputs = crate::types::DualPrfOutputs {
         chacha20_prf_output_base64: request.dual_prf_outputs.chacha20_prf_output,
@@ -200,12 +200,12 @@ pub async fn handle_derive_near_keypair_and_encrypt(
                 }
             }
             Err(e) => {
-                info!("RUST: Transaction signing failed: {}", e);
+                warn!("RUST: Transaction signing failed: {}", e);
                 None
             }
         }
     } else {
-        info!("RUST: No transaction signing requested - optional parameters not provided");
+        debug!("[rust wasm]: No transaction signing requested: parameters not provided");
         None
     };
 

--- a/sdk/src/wasm_signer_worker/src/handlers/handle_request_registration_credential_confirmation.rs
+++ b/sdk/src/wasm_signer_worker/src/handlers/handle_request_registration_credential_confirmation.rs
@@ -1,5 +1,5 @@
 use crate::types::wasm_to_json::ToJson;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json;
 use serde_wasm_bindgen;
 use wasm_bindgen::prelude::*;

--- a/sdk/src/wasm_signer_worker/src/handlers/handle_sign_nep413_message.rs
+++ b/sdk/src/wasm_signer_worker/src/handlers/handle_sign_nep413_message.rs
@@ -4,7 +4,7 @@
 // *                                                                            *
 // ******************************************************************************
 use crate::encoders::base64_standard_encode;
-use log::info;
+use log::debug;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
@@ -75,7 +75,7 @@ impl SignNep413Result {
 pub async fn handle_sign_nep413_message(
     request: SignNep413Request,
 ) -> Result<SignNep413Result, String> {
-    info!("RUST: Starting NEP-413 message signing");
+    debug!("RUST: Starting NEP-413 message signing");
 
     // Decode and validate nonce is exactly 32 bytes
     let nonce_bytes = crate::encoders::base64_standard_decode(&request.nonce)
@@ -121,7 +121,7 @@ pub async fn handle_sign_nep413_message(
     let serialized =
         borsh::to_vec(&payload).map_err(|e| format!("Borsh serialization failed: {}", e))?;
 
-    info!(
+    debug!(
         "RUST: NEP-413 payload serialized with Borsh ({} bytes)",
         serialized.len()
     );
@@ -131,7 +131,7 @@ pub async fn handle_sign_nep413_message(
     let mut prefixed_data = prefix.to_le_bytes().to_vec();
     prefixed_data.extend_from_slice(&serialized);
 
-    info!(
+    debug!(
         "RUST: NEP-413 prefix added, total data size: {} bytes",
         prefixed_data.len()
     );
@@ -142,7 +142,7 @@ pub async fn handle_sign_nep413_message(
     hasher.update(&prefixed_data);
     let hash = hasher.finalize();
 
-    info!("RUST: SHA-256 hash computed");
+    debug!("RUST: SHA-256 hash computed");
 
     // Sign the hash using the Ed25519 private key
     use ed25519_dalek::Signer;
@@ -156,7 +156,7 @@ pub async fn handle_sign_nep413_message(
     // Encode signature as base64
     let signature_b64 = base64_standard_encode(&signature.to_bytes());
 
-    info!("RUST: NEP-413 message signed successfully");
+    debug!("RUST: NEP-413 message signed successfully");
 
     Ok(SignNep413Result::new(
         request.account_id,

--- a/sdk/src/wasm_signer_worker/src/handlers/handle_sign_transaction_with_keypair.rs
+++ b/sdk/src/wasm_signer_worker/src/handlers/handle_sign_transaction_with_keypair.rs
@@ -11,7 +11,6 @@ use crate::transaction::{
 };
 use crate::types::wasm_to_json::WasmSignedTransaction;
 use bs58;
-use log::info;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use wasm_bindgen::prelude::*;
@@ -50,9 +49,8 @@ pub struct SignTransactionWithKeyPairRequest {
 pub async fn handle_sign_transaction_with_keypair(
     request: SignTransactionWithKeyPairRequest,
 ) -> Result<TransactionSignResult, String> {
-    let mut logs: Vec<String> = Vec::new();
-    info!("RUST: WASM binding - starting transaction signing with provided private key");
 
+    let mut logs: Vec<String> = Vec::new();
     // Parse the private key from NEAR format (ed25519:base58_encoded_64_bytes)
     let private_key_str = if request.near_private_key.starts_with("ed25519:") {
         &request.near_private_key[8..] // Remove "ed25519:" prefix

--- a/sdk/src/wasm_signer_worker/src/handlers/mod.rs
+++ b/sdk/src/wasm_signer_worker/src/handlers/mod.rs
@@ -26,25 +26,12 @@ pub use handle_check_can_register_user::{
     CheckCanRegisterUserRequest, RegistrationCheckRequest, RegistrationCheckResult,
     RegistrationInfoStruct,
 };
-pub use handle_decrypt_private_key_with_prf::{
-    ExportNearKeypairUiRequest, ExportNearKeypairUiResult,
-};
+pub use handle_decrypt_private_key_with_prf::ExportNearKeypairUiRequest;
 pub use handle_extract_cose_public_key::{CoseExtractionResult, ExtractCoseRequest};
 pub use handle_recover_keypair_from_passkey::{RecoverKeypairRequest, RecoverKeypairResult};
-pub use handle_request_registration_credential_confirmation::{
-    RegistrationCredentialConfirmationRequest, RegistrationCredentialConfirmationResult,
-};
+pub use handle_request_registration_credential_confirmation::RegistrationCredentialConfirmationRequest;
 pub use handle_sign_nep413_message::{SignNep413Request, SignNep413Result};
 pub use handle_sign_transaction_with_keypair::SignTransactionWithKeyPairRequest;
 pub use handle_sign_transactions_with_actions::{
     KeyActionResult, SignTransactionsWithActionsRequest, TransactionPayload,
 };
-
-// Transaction confirmation utilities
-pub use confirm_tx_details::{
-    compute_intent_digest_from_js_inputs, create_transaction_summary, generate_request_id,
-    request_user_confirmation, request_user_confirmation_with_config, ConfirmationResult,
-};
-
-// Confirmation configuration types (from types module)
-pub use crate::types::handlers::{ConfirmationBehavior, ConfirmationConfig, ConfirmationUIMode};

--- a/sdk/src/wasm_signer_worker/src/tests/rpc_calls_tests.rs
+++ b/sdk/src/wasm_signer_worker/src/tests/rpc_calls_tests.rs
@@ -144,7 +144,6 @@ fn test_contract_registration_result() {
             credential_public_key: vec![0x04, 0x05, 0x06],
         }),
         signed_transaction_borsh: Some(vec![0x0a, 0x0b, 0x0c]),
-        pre_signed_delete_transaction: Some(vec![0x0d, 0x0e, 0x0f]),
     };
 
     assert_eq!(result.success, true);

--- a/sdk/src/wasm_signer_worker/src/types/handlers.rs
+++ b/sdk/src/wasm_signer_worker/src/types/handlers.rs
@@ -1,9 +1,6 @@
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-use crate::handlers::handle_derive_near_keypair_and_encrypt::DeriveNearKeypairAndEncryptResult;
-use crate::types::{SerializedCredential, SerializedRegistrationCredential, VrfChallenge};
-
 // ******************************************************************************
 // *                                                                            *
 // *                    SHARED AUTHENTICATOR OPTIONS TYPES                      *
@@ -108,23 +105,7 @@ pub struct TransactionContext {
     pub tx_block_hash: String,
 }
 
-// === VERIFICATION TYPE (deprecated - use RpcCallPayload) ===
-
-/// Consolidated verification type for all flows.
-/// Credentials are collected during the confirmation flow via the main thread.
-/// DEPRECATED: Use RpcCallPayload instead
-#[deprecated(note = "Use RpcCallPayload instead")]
-#[wasm_bindgen]
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct VerificationPayload {
-    #[wasm_bindgen(getter_with_clone, js_name = "contractId")]
-    pub contract_id: String,
-    #[wasm_bindgen(getter_with_clone, js_name = "nearRpcUrl")]
-    pub near_rpc_url: String,
-    #[wasm_bindgen(getter_with_clone, js_name = "vrfChallenge")]
-    pub vrf_challenge: Option<VrfChallenge>,
-}
+// NOTE: VerificationPayload was deprecated; use RpcCallPayload instead (struct removed).
 
 // === DECRYPTION TYPES ===
 

--- a/sdk/src/wasm_signer_worker/src/types/mod.rs
+++ b/sdk/src/wasm_signer_worker/src/types/mod.rs
@@ -15,4 +15,3 @@ pub use near::*;
 pub use progress::*;
 pub use wasm_to_json::*;
 pub use webauthn::*;
-pub use worker_messages::*;

--- a/sdk/src/wasm_signer_worker/src/types/near.rs
+++ b/sdk/src/wasm_signer_worker/src/types/near.rs
@@ -6,7 +6,6 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use serde_bytes;
 use sha2::{Digest, Sha256};
-use wasm_bindgen::prelude::*;
 
 // === CORE NEAR TYPES ===
 

--- a/sdk/src/wasm_signer_worker/src/types/progress.rs
+++ b/sdk/src/wasm_signer_worker/src/types/progress.rs
@@ -215,6 +215,7 @@ pub fn progress_step_name(step: ProgressStep) -> &'static str {
 }
 
 /// Convert ProgressStatus enum to readable string for debugging
+#[allow(dead_code)]
 pub fn progress_status_name(status: ProgressStatus) -> &'static str {
     match status {
         ProgressStatus::Progress => "progress",
@@ -225,6 +226,7 @@ pub fn progress_status_name(status: ProgressStatus) -> &'static str {
 }
 
 /// Enhanced logging helper that includes enum names for better debugging
+#[allow(dead_code)]
 pub fn log_progress_message(message_type: ProgressMessageType, step: ProgressStep, message: &str) {
     crate::log(&format!(
         "Progress: {} ({}) - {} ({}) - {}",

--- a/sdk/src/wasm_vrf_worker/src/handlers/handle_derive_vrf_keypair_from_prf.rs
+++ b/sdk/src/wasm_vrf_worker/src/handlers/handle_derive_vrf_keypair_from_prf.rs
@@ -1,5 +1,5 @@
 use wasm_bindgen::prelude::*;
-use log::{debug, error, info, warn};
+use log::{debug, error, warn};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/sdk/src/wasm_vrf_worker/src/handlers/handle_generate_vrf_keypair_bootstrap.rs
+++ b/sdk/src/wasm_vrf_worker/src/handlers/handle_generate_vrf_keypair_bootstrap.rs
@@ -1,7 +1,7 @@
 use crate::manager::VRFKeyManager;
 use crate::types::VRFInputData;
 use crate::types::VrfWorkerResponse;
-use log::{error, info};
+use log::{error, debug};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -22,11 +22,11 @@ pub fn handle_generate_vrf_keypair_bootstrap(
     payload: GenerateVrfKeypairBootstrapRequest,
 ) -> VrfWorkerResponse {
     let mut manager_mut = manager.borrow_mut();
-    info!("Generating bootstrap VRF keypair");
+    debug!("Generating bootstrap VRF keypair");
 
     match manager_mut.generate_vrf_keypair_bootstrap(payload.vrf_input_data) {
         Ok(bootstrap_data) => {
-            info!("VRF keypair bootstrap completed successfully");
+            debug!("VRF keypair bootstrap completed successfully");
             // Structure response to match expected format
             let response_data = serde_json::json!({
                 "vrf_public_key": bootstrap_data.vrf_public_key,

--- a/sdk/src/wasm_vrf_worker/src/handlers/handle_unlock_vrf_keypair.rs
+++ b/sdk/src/wasm_vrf_worker/src/handlers/handle_unlock_vrf_keypair.rs
@@ -1,7 +1,7 @@
 use crate::manager::VRFKeyManager;
 use crate::types::EncryptedVRFKeypair;
 use crate::types::VrfWorkerResponse;
-use log::{error, info};
+use log::error;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -46,7 +46,6 @@ pub fn handle_unlock_vrf_keypair(
         prf_key,
     ) {
         Ok(_) => {
-            info!("VRF keypair unlock successful");
             VrfWorkerResponse::success(message_id, None)
         }
         Err(e) => {

--- a/sdk/src/wasm_vrf_worker/src/lib.rs
+++ b/sdk/src/wasm_vrf_worker/src/lib.rs
@@ -1,4 +1,4 @@
-use log::{debug, info};
+use log::debug;
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
@@ -10,9 +10,11 @@ mod handlers;
 mod http;
 mod manager;
 mod shamir3pass;
-mod tests;
 mod types;
 mod utils;
+
+#[cfg(test)]
+mod tests;
 
 // Re-export important types and functions
 pub use config::*;

--- a/sdk/src/wasm_vrf_worker/src/manager.rs
+++ b/sdk/src/wasm_vrf_worker/src/manager.rs
@@ -3,7 +3,7 @@ use chacha20poly1305::{ChaCha20Poly1305, Nonce};
 use getrandom::getrandom;
 use hkdf::Hkdf;
 use js_sys::Date;
-use log::{debug, info, warn};
+use log::{debug, warn};
 use rand_core::SeedableRng;
 use sha2::{Digest, Sha256};
 // VRF and crypto imports
@@ -97,7 +97,7 @@ impl VRFKeyManager {
         &mut self,
         vrf_input_data: Option<VRFInputData>,
     ) -> VrfResult<GenerateVrfKeypairBootstrapResponse> {
-        info!("Generating VRF keypair for bootstrapping");
+        debug!("Generating VRF keypair for bootstrapping");
         debug!("VRF keypair will be stored in memory unencrypted until PRF encryption");
 
         // Clear any existing keypair (zeroization via ZeroizeOnDrop)
@@ -133,7 +133,7 @@ impl VRFKeyManager {
             result.vrf_challenge_data = Some(challenge_result);
         }
 
-        info!("VRF challenge generated successfully");
+        debug!("VRF challenge generated successfully");
         Ok(result)
     }
 
@@ -208,7 +208,7 @@ impl VRFKeyManager {
         near_account_id: String,
         keypair_data: VRFKeypairData,
     ) -> VrfResult<()> {
-        info!("Loading VRF keypair for {}", near_account_id);
+        debug!("Loading VRF keypair for {}", near_account_id);
         // Clear any existing keypair
         self.vrf_keypair.take();
         // Reconstruct ECVRFKeyPair from stored bytes


### PR DESCRIPTION
### Summary
- Cleaned wasm worker logs, build warnings, and dead import vars.
- Clean up legacy `presignedDeleteTransaction` functions, legacy `verify_and_register` functions, and legacy `compute_intent_digest` functions and associated structs.

### Improve Chainsig demo logs and toasts
- Improve RPC error messages in toasts
- Restyle toast close button