### PR TITLE
CSP-safe Drawer + Export Viewer: light DOM composition, slot-like adoption, z-index fixes, progressive Shadow DOM fallback

### DIFF
--- a/examples/tatchi-docs/index.html
+++ b/examples/tatchi-docs/index.html
@@ -16,14 +16,17 @@
       (function(){
         try {
           var ls = (localStorage.getItem('vitepress-theme-appearance') || '').replace(/\"/g,'');
-          var mode = (ls === 'dark' || ls === 'light')
-            ? ls
-            : (document.documentElement.classList.contains('dark')
-                ? 'dark'
-                : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'));
+          // Default to dark when no preference is stored yet
+          var hasStored = (ls === 'dark' || ls === 'light');
+          var mode = hasStored ? ls : 'dark';
+          if (!hasStored) {
+            localStorage.setItem('vitepress-theme-appearance', mode)
+          }
+          // Keep SDK/theme hooks in sync with environment by reflecting on <html>
+          document.documentElement.classList.toggle('dark', mode === 'dark');
           document.documentElement.setAttribute('data-w3a-theme', mode);
           document.addEventListener('DOMContentLoaded', function(){
-            try { document.body.setAttribute('data-w3a-theme', mode) } catch(e){}
+            document.body.setAttribute('data-w3a-theme', mode)
           });
         } catch(e) {}
       })();

--- a/examples/tatchi-docs/src/components/DemoPage.tsx
+++ b/examples/tatchi-docs/src/components/DemoPage.tsx
@@ -507,7 +507,7 @@ export const DemoPage: React.FC = () => {
               loadingText="Signing..."
               variant="secondary"
               size="medium"
-              style={{ flex: 1 }}
+              style={{ flex: 1, minWidth: 200 }}
             >
               Drawer + Skip Confirm
             </LoadingButton>

--- a/examples/tatchi-docs/src/components/Navbar/NavbarProfileOverlay.tsx
+++ b/examples/tatchi-docs/src/components/Navbar/NavbarProfileOverlay.tsx
@@ -71,7 +71,8 @@ export const NavbarProfileOverlay: React.FC = () => {
   const overlay = (
     <div
       ref={btnRef}
-      style={{ position: 'fixed', top: '0.5rem', right: '0.5rem', zIndex: 2147483647, pointerEvents: 'auto' }}
+      // Keep this overlay above site content, but below wallet/SDK modals
+      style={{ position: 'fixed', top: '0.5rem', right: '0.5rem', zIndex: 2147483646, pointerEvents: 'auto' }}
       aria-hidden={false}
     >
       <TatchiProfileSettingsButton

--- a/sdk/src/core/WebAuthnManager/LitComponents/ExportPrivateKey/iframe-export-bootstrap-script.ts
+++ b/sdk/src/core/WebAuthnManager/LitComponents/ExportPrivateKey/iframe-export-bootstrap-script.ts
@@ -68,7 +68,9 @@ function getViewer(): HTMLElement & { theme?: string; variant?: string; accountI
   let viewer = drawer.querySelector(W3A_EXPORT_KEY_VIEWER_ID) as any;
   if (!viewer) {
     viewer = document.createElement(W3A_EXPORT_KEY_VIEWER_ID);
-    drawer.appendChild(viewer);
+    // Prefer appending directly into the drawer's declared content root when present
+    const target = (drawer as any).contentRoot || drawer.querySelector('.above-fold') || drawer.querySelector('.body') || drawer;
+    target.appendChild(viewer);
   }
   return viewer;
 }

--- a/sdk/src/core/WebAuthnManager/LitComponents/ExportPrivateKey/iframe-host.ts
+++ b/sdk/src/core/WebAuthnManager/LitComponents/ExportPrivateKey/iframe-host.ts
@@ -157,9 +157,9 @@ export class IframeExportHost extends LitElementWithProps {
           <link rel="stylesheet" href="${base}wallet-service.css" />
           <!-- Component palette/tokens for host elements (e.g., <w3a-drawer>) -->
           ${isAbsoluteBase ? `<link rel="stylesheet" href="${base}w3a-components.css" />` : ''}
-          <!-- Preload component styles to avoid first-open FOUC when base is absolute -->
-          ${isAbsoluteBase ? `<link rel="preload" as="style" href="${base}drawer.css" />` : ''}
-          ${isAbsoluteBase ? `<link rel="preload" as="style" href="${base}export-viewer.css" />` : ''}
+          <!-- Ensure critical component styles (strict CSP: external only, no inline) -->
+          ${isAbsoluteBase ? `<link rel="stylesheet" href="${base}drawer.css" data-w3a-drawer-css />` : ''}
+          ${isAbsoluteBase ? `<link rel="stylesheet" href="${base}export-viewer.css" data-w3a-export-viewer-css />` : ''}
           <script type="module" crossorigin="anonymous" src="${base}${viewerBundle}"></script>
           <script type="module" crossorigin="anonymous" src="${base}${bootstrap}"></script>
         </head>

--- a/sdk/src/core/WebAuthnManager/LitComponents/ExportPrivateKey/viewer.ts
+++ b/sdk/src/core/WebAuthnManager/LitComponents/ExportPrivateKey/viewer.ts
@@ -52,7 +52,13 @@ export class ExportPrivateKeyViewer extends LitElementWithProps {
   protected getComponentPrefix(): string { return 'export'; }
 
   protected createRenderRoot(): HTMLElement | DocumentFragment {
-    const root = super.createRenderRoot();
+    // Prefer Shadow DOM to scope styles when constructable stylesheets are supported.
+    // Fallback to light DOM for strict-CSP + legacy engines (document-level <link> will style it).
+    const supportsConstructable =
+      typeof ShadowRoot !== 'undefined'
+      && 'adoptedStyleSheets' in ShadowRoot.prototype
+      && 'replaceSync' in (CSSStyleSheet.prototype as any);
+    const root = supportsConstructable ? super.createRenderRoot() : (this as unknown as HTMLElement);
     // Adopt export-viewer.css for structural + visual styles
     const p1 = ensureExternalStyles(root as ShadowRoot | DocumentFragment | HTMLElement, 'export-viewer.css', 'data-w3a-export-viewer-css');
     this._stylePromises.push(p1);
@@ -61,6 +67,10 @@ export class ExportPrivateKeyViewer extends LitElementWithProps {
     const p2 = ensureExternalStyles(root as ShadowRoot | DocumentFragment | HTMLElement, 'w3a-components.css', 'data-w3a-components-css');
     this._stylePromises.push(p2);
     p2.catch(() => {});
+    // Ensure drawer structural styles are available before first paint to prevent transparent background
+    const p3 = ensureExternalStyles(root as ShadowRoot | DocumentFragment | HTMLElement, 'drawer.css', 'data-w3a-drawer-css');
+    this._stylePromises.push(p3);
+    p3.catch(() => {});
     return root;
   }
 

--- a/sdk/src/core/WebAuthnManager/LitComponents/LitElementWithProps.ts
+++ b/sdk/src/core/WebAuthnManager/LitComponents/LitElementWithProps.ts
@@ -37,25 +37,7 @@ export class LitElementWithProps extends LitElement {
   // Fallback sheet attached to the Document (constructable stylesheet) + a per-instance class
   private _varsDocSheet: CSSStyleSheet | null = null;
   private _varsClassName: string | null = null;
-  // Detect whether inline style application is allowed under current CSP.
-  // If style-src forbids inline styles, setting element.style will be ignored
-  // and trigger console violations in production. We degrade gracefully by
-  // skipping dynamic inline styling in that case and relying on CSS fallbacks.
-  private static readonly inlineStyleAllowed: boolean = (() => {
-    try {
-      if (typeof document === 'undefined') return true;
-      const probe = document.createElement('div');
-      probe.style.color = 'rgb(1, 2, 3)';
-      // Append to DOM to ensure computed styles reflect policy
-      (document.body || document.documentElement).appendChild(probe);
-      const applied = getComputedStyle(probe).color.includes('1, 2, 3');
-      probe.remove();
-      return applied;
-    } catch {
-      // Default to allowed in non-browser contexts
-      return true;
-    }
-  })();
+  // No inline style capability check: components never write inline styles.
 
   /**
    * Optional: Subclasses can provide a list of imported custom element classes they rely on

--- a/sdk/src/core/WebAuthnManager/LitComponents/css/export-viewer.css
+++ b/sdk/src/core/WebAuthnManager/LitComponents/css/export-viewer.css
@@ -5,6 +5,8 @@
 */
 
 :host { display: block; position: relative; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif; }
+/* Light DOM fallback when ShadowRoot is not used */
+w3a-export-key-viewer { display: block; position: relative; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif; }
 
 .content { display: flex; flex-direction: column; gap: 1rem; }
 @media (min-width: 769px) {

--- a/sdk/src/react/components/ProfileSettingsButton/LinkedDevicesModal.css
+++ b/sdk/src/react/components/ProfileSettingsButton/LinkedDevicesModal.css
@@ -6,7 +6,8 @@
   left: 0;
   height: 100%;
   width: 100%;
-  z-index: 1000;
+  /* Ensure this modal sits above high z-index overlays (wallet iframe, profile overlay) */
+  z-index: 2147483648;
   background: oklch(0.2 0.01 240 / 0.8);
   backdrop-filter: blur(8px);
   display: flex;
@@ -18,7 +19,7 @@
 
 .w3a-access-keys-modal-inner {
   position: relative;
-  z-index: 1001;
+  z-index: 2147483649;
   display: grid;
   place-items: center;
   height: 100%;

--- a/sdk/src/react/components/ProfileSettingsButton/index.tsx
+++ b/sdk/src/react/components/ProfileSettingsButton/index.tsx
@@ -324,10 +324,7 @@ const ProfileSettingsButtonInner: React.FC<ProfileSettingsButtonProps> = ({
             setShowQRScanner(false);
           }}
           onEvent={(event) => deviceLinkingScannerParams?.onEvent?.(event)}
-        />, (portalTarget
-          || ((refs.buttonRef.current?.getRootNode?.() instanceof ShadowRoot)
-              ? (refs.buttonRef.current!.getRootNode() as ShadowRoot)
-              : document.body)))}
+        />, (portalTarget || document.body))}
 
       {/* Linked Devices Modal (portaled to nearest root for robustness) */}
       {createPortal(
@@ -335,10 +332,7 @@ const ProfileSettingsButtonInner: React.FC<ProfileSettingsButtonProps> = ({
           nearAccountId={nearAccountId!}
           isOpen={showLinkedDevices}
           onClose={() => setShowLinkedDevices(false)}
-        />, (portalTarget
-          || ((refs.buttonRef.current?.getRootNode?.() instanceof ShadowRoot)
-              ? (refs.buttonRef.current!.getRootNode() as ShadowRoot)
-              : document.body)))}
+        />, (portalTarget || document.body))}
     </div>
   );
 };

--- a/sdk/src/react/components/QRCodeScanner.css
+++ b/sdk/src/react/components/QRCodeScanner.css
@@ -3,7 +3,8 @@
 .qr-scanner-modal {
   position: fixed;
   inset: 0;
-  z-index: 9999;
+  /* Sit above wallet iframe and profile overlay layers */
+  z-index: 2147483648;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary 

### Fix Export Key Drawer / Content styling issues.
Fix issue where content was not being adopted into Drawer slot.
- Previously we removed Drawer's ShadowDOM/slot model because of issues with CSS Var variables not being shared between composed components. This caused content to be rendered outside of the Drawer slot (as there was no <slot>)
- Now: Drawer stays in light DOM with a stable contentRoot and a slot-like adoption helper to place late-added children.

Now the Composition model is:
- Drawer remains light DOM and exposes contentRoot as the stable container for consumer content.
- Late-added children are auto-moved into .above-fold via MutationObserver.
- Export viewer bootstrap appends to drawer.contentRoot (with .above-fold/.body fallback).

Drawer intentionally avoids Shadow DOM to keep CSP simple and CSS vars shareable; we accept minor encapsulation trade-offs in exchange for compatibility.

### Z-index modal fixes:
- QR Scanner and Linked Devices modals portal to document.body to render above overlays.
- Docs overlay z-index lowered beneath wallet/modals.
