### PR TITLE
Add dev/staging Cloudflare deployment for docs + R2 publishing

### DIFF
--- a/.github/workflows/deploy-docs-dev.yml
+++ b/.github/workflows/deploy-docs-dev.yml
@@ -50,6 +50,17 @@ jobs:
         run: pnpm build:sdk-prod
 
       - name: Build docs app (examples/tatchi-docs)
+        env:
+          VITE_RELAYER_URL: ${{ vars.VITE_RELAYER_URL }}
+          VITE_RELAYER_ACCOUNT_ID: ${{ vars.VITE_RELAYER_ACCOUNT_ID }}
+          VITE_WEBAUTHN_CONTRACT_ID: ${{ vars.VITE_WEBAUTHN_CONTRACT_ID }}
+          VITE_NEAR_NETWORK: ${{ vars.VITE_NEAR_NETWORK }}
+          VITE_NEAR_RPC_URL: ${{ vars.VITE_NEAR_RPC_URL }}
+          VITE_NEAR_EXPLORER: ${{ vars.VITE_NEAR_EXPLORER }}
+          VITE_WALLET_ORIGIN: ${{ vars.VITE_WALLET_ORIGIN }}
+          VITE_WALLET_SERVICE_PATH: ${{ vars.VITE_WALLET_SERVICE_PATH }}
+          VITE_RP_ID_BASE: ${{ vars.VITE_RP_ID_BASE }}
+          VITE_SDK_BASE_PATH: ${{ vars.VITE_SDK_BASE_PATH }}
         run: pnpm -C examples/tatchi-docs build
 
       - name: Publish SDK artifacts to Cloudflare R2 (dev)


### PR DESCRIPTION
Add a dedicated GitHub Actions workflow for deploying the docs site to Cloudflare Pages on dev branch pushes, using a separate development environment and the existing Cloudflare `tatchi-vite-secure` (tatchi-docs) Pages project