### PR TITLE
Add DKIM‑based email recovery relay and zk‑email worker

### DIFF
--- a/.github/workflows/deploy-zk-email-cloudflare-worker.yml
+++ b/.github/workflows/deploy-zk-email-cloudflare-worker.yml
@@ -1,0 +1,87 @@
+name: deploy-zk-email-cloudflare-worker
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deployment environment (must match GitHub Environment name with secrets)"
+        required: false
+        default: "production"
+
+jobs:
+  deploy-zk-email-worker:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.inputs.environment || 'production' }}
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install Wrangler
+        run: pnpm add -g wrangler@4
+
+      - name: Deploy zk-email Cloudflare Worker
+        working-directory: examples/zk-email-cloudflare-worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RELAYER_URL: ${{ secrets.VITE_RELAYER_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RELAYER_URL:-}" ]; then
+            echo "VITE_RELAYER_URL (RELAYER_URL) secret is not set" >&2
+            exit 1
+          fi
+          wrangler deploy --var RELAYER_URL="${RELAYER_URL}"
+
+      - name: Configure Email Routing for reset@web3authn.org
+        if: env.CLOUDFLARE_ZONE_ID != ''
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: |
+          set -euo pipefail
+          API="https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/email/routing/rules"
+          echo "Creating Email Routing rule for reset@web3authn.org → zk-email-cloudflare-worker"
+          # NOTE: Payload schema may need adjustment to match the latest
+          # Cloudflare Email Routing API. See Cloudflare docs for details.
+          curl -sS -X POST "$API" \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data @- << 'JSON'
+          {
+            "enabled": true,
+            "name": "reset@web3authn.org to zk-email-cloudflare-worker",
+            "matchers": [
+              {
+                "type": "recipient",
+                "value": "reset@web3authn.org"
+              }
+            ],
+            "actions": [
+              {
+                "type": "worker",
+                "value": {
+                  "worker": {
+                    "name": "zk-email-cloudflare-worker"
+                  }
+                }
+              }
+            ]
+          }
+          JSON

--- a/docs/delegate-actions.md
+++ b/docs/delegate-actions.md
@@ -142,20 +142,23 @@
 - Add a config toggle `enableDelegateActions` (default: off) to reduce risk in early rollout. When disabled, SDK methods throw a clear “feature disabled” error.
 
 **Concrete Task Checklist**
-- Worker
-  - Add `SignDelegateAction` variants to `WorkerRequestType`/`WorkerResponseType` and map in `lib.rs`.
-  - Implement `handle_sign_delegate_action.rs` with confirm‑verify‑decrypt‑sign and progress messages.
-  - Implement NEP‑461 prefix encoding helpers and delegate Borsh schema.
-  - Re‑export new types for TS and add wasm_bindgen wrappers.
-- SDK
-  - Implement `sdk/src/core/TatchiPasskey/delegateAction.ts` and public API in `TatchiPasskey/index.ts`.
-  - Add `signDelegateAction` handler under `SignerWorkerManager/handlers/` and wire in the manager index.
-  - Add TS types in `sdk/src/core/types/delegate.ts` and map worker req/resp in `types/signer-worker.ts`.
-  - Add unit tests for encoding compatibility and key mismatch guard.
-- Wallet Iframe
-  - Add `'PM_SIGN_DELEGATE_ACTION'` envelope and payload types in `shared/messages.ts`.
-  - Implement host handler in `host/wallet-iframe-handlers.ts` and router method in `client/router.ts`.
-  - Extend confirm bridge consumer to render `type: 'signDelegateAction'` payloads.
+- [x] Wire `SignedDelegate` action enums
+  - [x] Add `SignedDelegate` to Rust `ActionType` in `sdk/src/wasm_signer_worker/src/actions.rs`.
+  - [x] Add `SignedDelegate` to TS `ActionType` in `sdk/src/core/types/actions.ts`.
+- [ ] Worker
+  - [ ] Add `SignDelegateAction` variants to `WorkerRequestType`/`WorkerResponseType` and map in `lib.rs`.
+  - [ ] Implement `handle_sign_delegate_action.rs` with confirm‑verify‑decrypt‑sign and progress messages.
+  - [ ] Implement NEP‑461 prefix encoding helpers and delegate Borsh schema.
+  - [ ] Re‑export new types for TS and add wasm_bindgen wrappers.
+- [ ] SDK
+  - [ ] Implement `sdk/src/core/TatchiPasskey/delegateAction.ts` and public API in `TatchiPasskey/index.ts`.
+  - [ ] Add `signDelegateAction` handler under `SignerWorkerManager/handlers/` and wire in the manager index.
+  - [ ] Add TS types in `sdk/src/core/types/delegate.ts` and map worker req/resp in `types/signer-worker.ts`.
+  - [ ] Add unit tests for encoding compatibility and key mismatch guard.
+- [ ] Wallet Iframe
+  - [ ] Add `'PM_SIGN_DELEGATE_ACTION'` envelope and payload types in `shared/messages.ts`.
+  - [ ] Implement host handler in `host/wallet-iframe-handlers.ts` and router method in `client/router.ts`.
+  - [ ] Extend confirm bridge consumer to render `type: 'signDelegateAction'` payloads.
 
 **Open Questions**
 - Do we need a dedicated progress phase set (e.g., `delegate-signing-progress`) or is reusing action phases sufficient for v1?

--- a/docs/global-contracts-for-sdk.md
+++ b/docs/global-contracts-for-sdk.md
@@ -1,0 +1,450 @@
+**Global Contracts – SDK / WASM Signer Worker Implementation Plan**
+
+- Goal: Add first‑class support for NEP‑0591 Global Contracts in the Web3Authn SDK transaction flow, so the WASM signer worker can sign transactions containing `DeployGlobalContract` and `UseGlobalContract` actions.
+- Scope: Changes are confined to the SDK (`sdk/`) and the Rust WASM signer worker crate (`sdk/src/wasm_signer_worker`), reusing the existing `signTransactionsWithActions` flow. Contract code (`email-recoverer`) and CLI tooling are already handled elsewhere.
+
+**References**
+- NEP‑0591 Global Contracts spec.
+- `@near-js/transactions` v2.4.0 global contract types:
+  - `GlobalContractDeployMode`, `GlobalContractIdentifier`
+  - `DeployGlobalContract`, `UseGlobalContract`
+  - `action_creators.deployGlobalContract`, `action_creators.useGlobalContract`
+
+---
+
+## 1. Data Model Changes in WASM Signer Worker (Rust)
+
+**1.1 Extend NEAR core types**
+
+Files (Rust crate under `sdk/src/wasm_signer_worker`):
+- `sdk/src/wasm_signer_worker/src/types/near.rs`
+
+Tasks:
+
+- Add NEP‑0591 enums to mirror `@near-js/transactions`:
+
+  ```rust
+  #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+  #[serde(rename_all = "camelCase")]
+  pub enum GlobalContractDeployMode {
+      CodeHash,
+      AccountId,
+  }
+
+  #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+  #[serde(rename_all = "camelCase")]
+  pub enum GlobalContractIdentifier {
+      CodeHash(CryptoHash),   // 32‑byte code hash
+      AccountId(AccountId),   // owner account ID
+  }
+  ```
+
+- Extend the internal `Action` enum with global‑contract actions:
+
+  ```rust
+  #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+  #[serde(rename_all = "camelCase")]
+  pub enum Action {
+      CreateAccount,
+      DeployContract { #[serde(with = "serde_bytes")] code: Vec<u8> },
+      FunctionCall(Box<FunctionCallAction>),
+      Transfer { deposit: Balance },
+      Stake { stake: Balance, public_key: PublicKey },
+      AddKey { public_key: PublicKey, access_key: AccessKey },
+      DeleteKey { public_key: PublicKey },
+      DeleteAccount { beneficiary_id: AccountId },
+      DeployGlobalContract {
+          #[serde(with = "serde_bytes")]
+          code: Vec<u8>,
+          deploy_mode: GlobalContractDeployMode,
+      },
+      UseGlobalContract {
+          contract_identifier: GlobalContractIdentifier,
+      },
+  }
+  ```
+
+- Ensure Borsh layout matches near‑primitives:
+  - Fields and variant order should mirror the protocol (use `@near-js/transactions` as a reference when validating serialized bytes).
+  - Add unit tests that:
+    - Create `Action::DeployGlobalContract` and `Action::UseGlobalContract` values.
+    - Borsh‑serialize them and compare against bytes produced by `@near-js/transactions` for the same actions.
+
+---
+
+**1.2 Extend `ActionParams` JSON schema**
+
+Files (Rust crate under `sdk/src/wasm_signer_worker`):
+- `sdk/src/wasm_signer_worker/src/actions.rs`
+
+Tasks:
+
+- Extend `ActionParams` enum (JSON representation coming from TS) with two new variants:
+
+  ```rust
+  #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+  #[serde(tag = "action_type")]
+  pub enum ActionParams {
+      CreateAccount,
+      DeployContract { code: Vec<u8> },
+      FunctionCall { method_name: String, args: String, gas: String, deposit: String },
+      Transfer { deposit: String },
+      Stake { stake: String, public_key: String },
+      AddKey { public_key: String, access_key: String },
+      DeleteKey { public_key: String },
+      DeleteAccount { beneficiary_id: String },
+      // New: NEP‑0591 actions
+      DeployGlobalContract {
+          code: Vec<u8>,
+          // "CodeHash" | "AccountId" (same strings as ActionType / TS side)
+          deploy_mode: String,
+      },
+      UseGlobalContract {
+          // Exactly one of these must be set by TS side
+          account_id: Option<String>,
+          code_hash: Option<String>, // bs58 string or 32‑byte hex; see TS mapping
+      },
+  }
+  ```
+
+- Extend `ActionType` enum used internally in `actions.rs` with:
+
+  ```rust
+  pub enum ActionType {
+      CreateAccount,
+      DeployContract,
+      FunctionCall,
+      Transfer,
+      Stake,
+      AddKey,
+      DeleteKey,
+      DeleteAccount,
+      DeployGlobalContract,
+      UseGlobalContract,
+  }
+  ```
+
+---
+
+**1.3 Add action handlers for global contracts**
+
+Files (Rust crate under `sdk/src/wasm_signer_worker`):
+- `sdk/src/wasm_signer_worker/src/actions.rs`
+
+Tasks:
+
+- Implement `DeployGlobalContractActionHandler` and `UseGlobalContractActionHandler` analogous to existing handlers:
+
+  ```rust
+  pub struct DeployGlobalContractActionHandler;
+  pub struct UseGlobalContractActionHandler;
+  ```
+
+- Validation rules:
+
+  - `DeployGlobalContract`:
+    - `code` must be non‑empty.
+    - `deploy_mode` must be `"CodeHash"` or `"AccountId"`; anything else returns a clear error.
+  - `UseGlobalContract`:
+    - Exactly one of `account_id` or `code_hash` must be present (not both).
+    - If `account_id` is set: validate as `AccountId::from_str`.
+    - If `code_hash` is set:
+      - Decide on encoding (recommend: base58 string matching `@near-js/transactions` `CodeHash`).
+      - Decode to 32‑byte array, then to `CryptoHash`.
+
+- Build logic:
+
+  - `DeployGlobalContractActionHandler::build_action`:
+
+    ```rust
+    fn build_action(&self, params: &ActionParams) -> Result<Action, String> {
+        if let ActionParams::DeployGlobalContract { code, deploy_mode } = params {
+            let mode = match deploy_mode.as_str() {
+                "CodeHash" => GlobalContractDeployMode::CodeHash,
+                "AccountId" => GlobalContractDeployMode::AccountId,
+                other => return Err(format!("Invalid deploy_mode: {}", other)),
+            };
+            Ok(Action::DeployGlobalContract {
+                code: code.clone(),
+                deploy_mode: mode,
+            })
+        } else {
+            Err("Invalid params for DeployGlobalContract action".to_string())
+        }
+    }
+    ```
+
+  - `UseGlobalContractActionHandler::build_action`:
+
+    ```rust
+    fn build_action(&self, params: &ActionParams) -> Result<Action, String> {
+        if let ActionParams::UseGlobalContract { account_id, code_hash } = params {
+            let identifier = match (account_id, code_hash) {
+                (Some(id), None) => {
+                    let acc = id.parse::<AccountId>()
+                        .map_err(|e| format!("Invalid account_id: {}", e))?;
+                    GlobalContractIdentifier::AccountId(acc)
+                }
+                (None, Some(hash_str)) => {
+                    // Assuming base58 encoding for consistency with JS
+                    let bytes = bs58::decode(hash_str)
+                        .into_vec()
+                        .map_err(|e| format!("Invalid code_hash: {}", e))?;
+                    if bytes.len() != 32 {
+                        return Err("code_hash must be 32 bytes".to_string());
+                    }
+                    let mut arr = [0u8; 32];
+                    arr.copy_from_slice(&bytes);
+                    GlobalContractIdentifier::CodeHash(CryptoHash::from_bytes(arr))
+                }
+                _ => {
+                    return Err("UseGlobalContract requires exactly one of account_id or code_hash".to_string());
+                }
+            };
+
+            Ok(Action::UseGlobalContract { contract_identifier: identifier })
+        } else {
+            Err("Invalid params for UseGlobalContract action".to_string())
+        }
+    }
+    ```
+
+- Wire handlers into `get_action_handler`:
+
+  ```rust
+  pub fn get_action_handler(params: &ActionParams) -> Result<Box<dyn ActionHandler>, String> {
+      match params {
+          ActionParams::FunctionCall { .. } => Ok(Box::new(FunctionCallActionHandler)),
+          ActionParams::Transfer { .. } => Ok(Box::new(TransferActionHandler)),
+          ActionParams::CreateAccount => Ok(Box::new(CreateAccountActionHandler)),
+          ActionParams::DeployContract { .. } => Ok(Box::new(DeployContractActionHandler)),
+          ActionParams::Stake { .. } => Ok(Box::new(StakeActionHandler)),
+          ActionParams::AddKey { .. } => Ok(Box::new(AddKeyActionHandler)),
+          ActionParams::DeleteKey { .. } => Ok(Box::new(DeleteKeyActionHandler)),
+          ActionParams::DeleteAccount { .. } => Ok(Box::new(DeleteAccountActionHandler)),
+          ActionParams::DeployGlobalContract { .. } => Ok(Box::new(DeployGlobalContractActionHandler)),
+          ActionParams::UseGlobalContract { .. } => Ok(Box::new(UseGlobalContractActionHandler)),
+      }
+  }
+  ```
+
+---
+
+**1.4. Confirmation / digest handling (UI summary)**
+
+Files (Rust crate under `sdk/src/wasm_signer_worker`):
+- `sdk/src/wasm_signer_worker/src/handlers/confirm_tx_details.rs`
+
+Tasks:
+
+- Extend any match statements that compute:
+  - Total attached deposit.
+  - Human‑readable summaries of actions.
+
+Guidelines:
+
+- Treat both `DeployGlobalContract` and `UseGlobalContract` as **0 deposit** actions (storage cost is internal to the protocol, not an attached deposit).
+- For confirmation UI summaries:
+  - `DeployGlobalContract`: show something like “Deploy global contract (mode: CodeHash/AccountId, code size: N bytes)”.
+  - `UseGlobalContract`: show “Use global contract by accountId: X” or “Use global contract by hash: <shortened hash>”.
+- Ensure the `intentDigest` covers the new action shapes exactly as encoded in `ActionParams[]` so the UI and WASM see the same payload.
+
+---
+
+## 2. TypeScript SDK Wiring for Global Actions
+
+Although the WASM signer worker is the source of truth for NEAR actions, we need matching TS types in the SDK so apps can request global‑contract actions.
+
+Files (SDK package under `sdk/src`):
+- `sdk/src/core/types/actions.ts`
+- `sdk/src/core/WebAuthnManager/LitComponents/common/tx-digest.ts`
+- Any call sites that construct `ActionArgs` for deploy flows (e.g. `sdk/src/server/core/AuthService.ts`, `sdk/src/core/rpcCalls.ts`, `sdk/src/core/TatchiPasskey/*.ts` helpers).
+
+**2.1 Extend `ActionType` and action unions**
+
+In `core/types/actions.ts`:
+
+- Extend `ActionType`:
+
+  ```ts
+  export enum ActionType {
+    CreateAccount = "CreateAccount",
+    DeployContract = "DeployContract",
+    FunctionCall = "FunctionCall",
+    Transfer = "Transfer",
+    Stake = "Stake",
+    AddKey = "AddKey",
+    DeleteKey = "DeleteKey",
+    DeleteAccount = "DeleteAccount",
+    DeployGlobalContract = "DeployGlobalContract",
+    UseGlobalContract = "UseGlobalContract",
+  }
+  ```
+
+- Add JS‑side action interfaces:
+
+  ```ts
+  export interface DeployGlobalContractAction {
+    type: ActionType.DeployGlobalContract;
+    code: Uint8Array | string;
+    // "CodeHash" | "AccountId"
+    deployMode: 'CodeHash' | 'AccountId';
+  }
+
+  export interface UseGlobalContractAction {
+    type: ActionType.UseGlobalContract;
+    // Exactly one of these should be set
+    accountId?: string;
+    // bs58‑encoded code hash
+    codeHash?: string;
+  }
+
+  export type ActionArgs =
+    | FunctionCallAction
+    | TransferAction
+    | CreateAccountAction
+    | DeployContractAction
+    | StakeAction
+    | AddKeyAction
+    | DeleteKeyAction
+    | DeleteAccountAction
+    | DeployGlobalContractAction
+    | UseGlobalContractAction;
+  ```
+
+- Extend `ActionArgsWasm` to mirror the Rust `ActionParams` layout:
+
+  ```ts
+  export type ActionArgsWasm =
+    | { action_type: ActionType.CreateAccount }
+    | { action_type: ActionType.DeployContract; code: number[] }
+    | { action_type: ActionType.DeployGlobalContract; code: number[]; deploy_mode: 'CodeHash' | 'AccountId' }
+    | {
+        action_type: ActionType.FunctionCall;
+        method_name: string;
+        args: string;
+        gas: string;
+        deposit: string;
+      }
+    | { action_type: ActionType.Transfer; deposit: string }
+    | { action_type: ActionType.Stake; stake: string; public_key: string }
+    | { action_type: ActionType.AddKey; public_key: string; access_key: string }
+    | { action_type: ActionType.DeleteKey; public_key: string }
+    | { action_type: ActionType.DeleteAccount; beneficiary_id: string }
+    | { action_type: ActionType.UseGlobalContract; account_id?: string; code_hash?: string };
+  ```
+
+**2.2 Mapping JS ↔ WASM action shapes**
+
+- Update `toActionArgsWasm(action: ActionArgs): ActionArgsWasm` to handle the two new cases:
+
+  ```ts
+  case ActionType.DeployGlobalContract:
+    return {
+      action_type: ActionType.DeployGlobalContract,
+      code: typeof action.code === 'string'
+        ? Array.from(new TextEncoder().encode(action.code))
+        : Array.from(action.code),
+      deploy_mode: action.deployMode,
+    };
+
+  case ActionType.UseGlobalContract:
+    return {
+      action_type: ActionType.UseGlobalContract,
+      account_id: action.accountId,
+      code_hash: action.codeHash,
+    };
+  ```
+
+- Update `validateActionArgsWasm`:
+  - `DeployGlobalContract`: ensure `code` is present and non‑empty; `deploy_mode` is `"CodeHash"` or `"AccountId"`.
+  - `UseGlobalContract`: ensure exactly one of `account_id` or `code_hash` is set.
+
+- Update `fromActionArgsWasm`:
+  - Convert `DeployGlobalContract` back into `DeployGlobalContractAction`.
+  - Convert `UseGlobalContract` back into `UseGlobalContractAction`.
+
+**2.3 Confirmation UI / digest**
+
+Files:
+- `sdk/src/core/WebAuthnManager/LitComponents/common/tx-digest.ts`
+
+Tasks:
+
+- Extend switch over `action_type` to include:
+
+  ```ts
+  case ActionType.DeployGlobalContract:
+    return { action_type: a.action_type, deploy_mode: a.deploy_mode, code_len: a.code?.length ?? 0 };
+  case ActionType.UseGlobalContract:
+    return { action_type: a.action_type, account_id: a.account_id, code_hash: a.code_hash };
+  ```
+
+- This ensures the digest covers global actions and the UI can render simple summaries.
+
+---
+
+## 3. How Apps Use Global Contract Actions via SDK
+
+With the above wiring in place, client code can request global‑contract operations using the existing `signTransactionsWithActions` path by constructing `ActionArgs` that include global actions:
+
+```ts
+// Example: user attaches a global email-recoverer contract and initializes it
+const tx = {
+  receiverId: userAccountId, // e.g. "bob.near"
+  actions: [
+    {
+      type: ActionType.UseGlobalContract,
+      accountId: GLOBAL_EMAIL_RECOVERER_ACCOUNT_ID,
+    },
+    {
+      type: ActionType.FunctionCall,
+      methodName: "new",
+      args: {
+        zk_email_verifier: "zk-email-verifier.testnet",
+        email_dkim_verifier: "email-dkim-verifier.testnet",
+        policy: null,
+        recovery_emails: [],
+      },
+      gas: "80000000000000",
+      deposit: "0",
+    },
+  ],
+};
+```
+
+The SDK will:
+
+- Convert these to `ActionArgsWasm` and then to Rust `ActionParams`.
+- Build proper NEP‑0591 `DeployGlobalContract` / `UseGlobalContract` `Action`s in the wasm‑signer‑worker.
+- Sign the resulting transaction with the user’s WebAuthn‑backed keypair, just like for existing actions.
+
+---
+
+## 4. Validation & Testing
+
+**Unit tests (Rust – WASM signer worker)**
+
+- Add tests in `sdk/src/wasm_signer_worker/src/tests/actions_tests.rs`:
+  - Validate `DeployGlobalContractActionHandler` and `UseGlobalContractActionHandler`:
+    - Reject invalid `deploy_mode`.
+    - Reject missing/duplicate `account_id` / `code_hash`.
+  - Ensure `build_action` produces `Action::DeployGlobalContract` / `Action::UseGlobalContract` with expected fields.
+
+- Add serialization parity tests:
+  - For a fixed `DeployGlobalContract` and `UseGlobalContract` action, compare Borsh bytes to those from `@near-js/transactions` for the same action payload (using a small helper script).
+
+**Unit tests (TS – SDK)**
+
+- Extend `core/types/actions.spec.ts` (or equivalent) to:
+  - Validate `toActionArgsWasm` / `fromActionArgsWasm` round‑trip for new action types.
+  - Validate `validateActionArgsWasm` error paths (e.g. both `account_id` and `code_hash` provided).
+
+**Integration tests**
+
+- Add a small end‑to‑end test that:
+  - Builds a transaction with `UseGlobalContract + FunctionCall(new)` for a dummy contract.
+  - Passes it through `signTransactionsWithActions`.
+  - Asserts that:
+    - The signed transaction contains the expected action sequence when decoded.
+    - The signer worker progress events still flow correctly.

--- a/docs/yubikey-backup.md
+++ b/docs/yubikey-backup.md
@@ -1,0 +1,82 @@
+# YubiKey Backup Flow (Single Device)
+
+This document describes how to treat a YubiKey as a **physical backup** for an existing Web3Authn account, using a single logged‑in device (no QR or second device required).
+
+The goal is:
+
+- You are logged in as `accountId` on device 1 (platform passkey).
+- You plug in a YubiKey.
+- You run a “link YubiKey backup” flow.
+- Afterward, you can use **either**:
+  - the original passkey, or
+  - the YubiKey
+  
+to authenticate and sign transactions for the **same** NEAR account.
+
+## High-Level Flow
+
+All of this happens while device 1 is logged in to `accountId`.
+
+1. **WebAuthn registration on the YubiKey (create + get)**
+   - Call `navigator.credentials.create()` with:
+     - `rp.id` = wallet RP ID (`example.localhost` or your production domain).
+     - `user.id` / `user.name` derived from `accountId` (same strategy as regular registration).
+     - `extensions.prf` enabled.
+   - This yields a **registration credential** with:
+     - Attestation object + COSE public key.
+     - Credential ID (`id` / `rawId`).
+   - Immediately follow with a constrained `navigator.credentials.get()`:
+     - `allowCredentials` contains only this `rawId`.
+     - `extensions.prf.eval.first/second` use salts derived from `accountId`.
+   - Extract dual PRF outputs from `get()`:
+     - `prf.results.first` → ChaCha20 PRF output.
+     - `prf.results.second` → Ed25519 PRF output.
+
+2. **Derive deterministic keys for the YubiKey**
+   - Using the PRF outputs and `accountId`:
+     - Derive a **deterministic VRF keypair** scoped to `accountId`.
+     - Derive a **deterministic NEAR ed25519 keypair** scoped to `accountId`.
+   - Encrypt and store these keys in the wallet’s IndexedDB, just like normal registration.
+
+3. **Register the YubiKey authenticator on the contract**
+   - Call the contract’s **link‑device style** method (e.g. `link_device_register_user`) with:
+     - `vrf_data` built from the YubiKey’s deterministic VRF public key and a fresh VRF challenge.
+     - `webauthn_registration` = the registration credential from `navigator.credentials.create()`.
+     - `authenticator_options` = origin policy + userVerification (same as normal registration).
+   - The contract:
+     - Verifies VRF data and WebAuthn attestation.
+     - Stores the new authenticator under `accountId`:
+       - Credential ID → COSE public key, transports, origin policy.
+       - VRF public keys (bootstrap + deterministic).
+
+4. **Add the YubiKey’s NEAR public key to the account**
+   - Using the logged‑in platform passkey session for `accountId`, send an `add_key` transaction:
+     - `public_key` = the YubiKey’s deterministic NEAR public key.
+     - Access type as per your policy (full access or function‑call).
+   - After this transaction lands:
+     - `accountId` has a new NEAR key controlled by the YubiKey.
+     - The contract already knows the YubiKey authenticator (from step 3).
+
+5. **Result**
+   - The same account (`accountId`) now has:
+     - Original platform passkey + NEAR keys.
+     - A YubiKey authenticator with:
+       - Stored COSE public key and transports.
+       - VRF public keys.
+       - A NEAR key registered on‑chain via `add_key`.
+   - Login and transaction signing work with either authenticator; the contract verifies:
+     - VRF data using the VRF public key for `accountId`.
+     - WebAuthn authentication using the stored COSE key.
+     - NEAR signature using the corresponding NEAR public key.
+
+## UX Considerations
+
+- **Two prompts at YubiKey registration time**:
+  - First prompt: `navigator.credentials.create()` to register the passkey.
+  - Second prompt: `navigator.credentials.get()` to obtain PRF outputs for key derivation.
+  - This happens once when linking the YubiKey; subsequent logins/transactions use the normal single‑prompt `get()` flow.
+
+- **Single device only**:
+  - Unlike the QR‑based device‑linking feature, this flow does not require a second device or a temporary keypair.
+  - It reuses the same account and session on device 1, treating the YubiKey as an additional authenticator plus an additional account key.
+

--- a/docs/zk-email-recovery.md
+++ b/docs/zk-email-recovery.md
@@ -1,0 +1,194 @@
+# ZK Email Recovery — Cloudflare Email Worker Plan
+
+Goal: wire a Cloudflare Email Worker that receives password‑reset / recovery emails (for example, `reset@web3authn.org`), parses them into JSON (including DKIM‑related headers), and forwards them to the existing Cloudflare Relay Worker at an HTTP endpoint such as `/reset-email`. The Email Worker stays “dumb” (no keys, no ZK); the Relay Worker + prover infrastructure handle DKIM verification, zk‑email proofs, and NEAR transactions.
+
+## 1. Install Wrangler
+
+- Ensure Node.js (LTS) and `npm` are installed.
+- Install or invoke Wrangler:
+  - `npm install -g wrangler`
+  - or run `npx wrangler --version` to use it ad‑hoc.
+- Log in once so Wrangler can manage your Cloudflare account:
+  - `wrangler login`
+
+## 2. Create an Email Worker project
+
+In a new, empty folder:
+
+- `mkdir zk-email-cloudflare-worker && cd zk-email-cloudflare-worker`
+- Initialize a Worker project:
+  - `wrangler init --from-dash zk-email-cloudflare-worker`
+  - or `wrangler init` and choose the “Hello World” template.
+
+Wrangler will create:
+
+- `wrangler.toml`
+- A JS/TS entry file (for example, `src/index.ts` or `src/worker.js`).
+
+## 3. Configure `wrangler.toml` for Email Workers
+
+Edit `wrangler.toml` to enable the email entrypoint:
+
+```toml
+name = "zk-email-cloudflare-worker"
+main = "src/email-worker.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["email"]
+
+# optional: set the account ID explicitly
+# account_id = "your-cloudflare-account-id"
+```
+
+- If you are using JavaScript instead of TypeScript, change `main` to `src/email-worker.js`.
+- Keep `compatibility_date` reasonably current; update it if Wrangler suggests it during deploys.
+
+## 4. Implement the Email Worker
+
+Create `src/email-worker.ts` (or `.js`) with an `email` handler that:
+
+- Filters for recovery addresses (for example, `reset@web3authn.org`).
+- Canonicalizes headers (including `DKIM-Signature`) into a JSON object.
+- POSTs that JSON to the Cloudflare Relay Worker (for example, `https://relay.tatchi.xyz/reset-email`).
+
+Example shape:
+
+```ts
+export default {
+  async email(message: EmailMessage, env: any, ctx: ExecutionContext) {
+    const relayerUrl = env.RELAYER_URL ?? "https://relay.tatchi.xyz";
+
+    // Serialize headers (including DKIM-Signature) to JSON
+    const headers: Record<string, string> = {};
+    for (const [key, value] of message.headers as any) {
+      headers[String(key).toLowerCase()] = String(value);
+    }
+
+    if (message.to === "reset@web3authn.org") {
+      const payload = {
+        to: message.to,
+        from: message.from,
+        subject: message.headers.get("subject") || "",
+        headers, // includes DKIM-Signature if present
+        // Optional: add a truncated/raw body snapshot if you need it server-side
+      };
+
+      const response = await fetch(`${relayerUrl}/reset-email`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        // Relay rejected or failed; treat as a hard failure for now.
+        message.setReject("Recovery relayer rejected email");
+        return;
+      }
+
+      // Optional: forward to a debug inbox for manual inspection.
+      await message.forward("your-debug-inbox@example.com");
+      return;
+    }
+
+    message.setReject("Unknown address");
+  },
+};
+```
+
+- For JavaScript, drop the type annotations and keep the same structure.
+- The Email Worker does not verify DKIM or run zk proofs; it only re‑packages the message and forwards it to the existing Relay Worker.
+
+## 5. Deploy the Email Worker
+
+From the project root:
+
+- `npx wrangler deploy`
+
+Wrangler will:
+
+- Build and upload the Worker.
+- Print the Worker name and confirm deployment.
+
+## 6. Wire Cloudflare Email Routing → Worker
+
+In the Cloudflare dashboard:
+
+- Navigate to **Email → Email Routing** for your domain.
+- Ensure MX records are set for the domain (Cloudflare will guide you if not).
+- Add a routing rule:
+  - **Destination address**: `reset@web3authn.org` (or your chosen recovery alias).
+  - **Action**: “Send to Worker”.
+  - **Worker**: `zk-email-cloudflare-worker` (the Worker you deployed above).
+
+Once this rule is active:
+
+- Any email sent to `reset@web3authn.org` will be delivered to your Email Worker.
+- The Worker runs the `email` handler, can log, forward, or call your zk‑email relayer.
+
+## 7. Next steps for zk‑email recovery
+
+This plan focuses on the Email Worker + Relay Worker boundary. To turn it into a full zk‑email recovery path:
+
+- Define the expected email format (subject/body fields) that encode `account_id`, `new_public_key`, and an optional nonce.
+- Implement `POST /reset-email` on the existing Cloudflare Relay Worker (`examples/relay-cloudflare-worker`) to:
+  - Accept the JSON payload from the Email Worker.
+  - Verify DKIM and structural constraints (either directly or via a backend/prover service).
+  - Run zk‑email proofs and submit transactions to:
+    - The global `ZkEmailVerifier` contract (for proof verification).
+    - The per‑user zk‑email‑recovery contract on NEAR (to add a new recovery key when policy is satisfied).
+- Add logging and metrics on both Workers for observability, and tests that send synthetic emails through Email Routing into the full Email Worker → Relay Worker → NEAR path.
+
+## 8. Email Worker runtime types
+
+Cloudflare’s Email Workers expose the following runtime types (see Cloudflare Email Routing docs for the canonical definitions). These are the types you interact with in the `email` handler above.
+
+### `ForwardableEmailMessage`
+
+```ts
+interface ForwardableEmailMessage<Body = unknown> {
+  readonly from: string;
+  readonly to: string;
+  readonly headers: Headers;
+  readonly raw: ReadableStream;
+  readonly rawSize: number;
+
+  // Constructor is provided by the platform, not used directly in Workers code:
+  // constructor(from: string, to: string, raw: ReadableStream | string);
+
+  setReject(reason: string): void;
+  forward(rcptTo: string, headers?: Headers): Promise<void>;
+  reply(message: EmailMessage): Promise<void>;
+}
+```
+
+- `from` / `to`: envelope sender/recipient.
+- `headers`: full email headers (including `DKIM-Signature` when present).
+- `raw` / `rawSize`: stream and size of the raw message.
+- `setReject(reason)`: permanently reject the email with an SMTP error and message.
+- `forward(rcptTo, headers?)`: forward the email to a verified destination, optionally adding `X-*` headers.
+- `reply(message)`: send a reply `EmailMessage` back to the sender.
+
+In the ES modules syntax, the `message` parameter in:
+
+```ts
+export default {
+  async email(message, env, ctx) {
+    // message is a ForwardableEmailMessage
+  },
+};
+```
+
+is a `ForwardableEmailMessage`.
+
+### `EmailMessage`
+
+```ts
+interface EmailMessage {
+  readonly from: string;
+  readonly to: string;
+}
+```
+
+This is used when composing replies with `message.reply(...)`:
+
+- `from`: envelope sender for the reply.
+- `to`: envelope recipient for the reply.

--- a/examples/tatchi-docs/src/components/AccountRecovery.tsx
+++ b/examples/tatchi-docs/src/components/AccountRecovery.tsx
@@ -10,6 +10,7 @@ import { useCarousel } from './Carousel2/CarouselProvider'
 import { useAuthMenuControl } from '../contexts/AuthMenuControl'
 import { useProfileMenuControl } from '../contexts/ProfileMenuControl'
 import './AccountRecovery.css'
+import { SetupEmailRecovery } from './SetupEmailRecovery';
 
 export function AccountRecovery() {
   const { accountInputState, tatchi, refreshLoginState, loginState, logout } = useTatchi()
@@ -49,33 +50,35 @@ export function AccountRecovery() {
 
   return (
     <GlassBorder style={{ maxWidth: 480, marginTop: '1rem' }}>
-      <div style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '0.5rem',
-        padding: '1rem'
-      }}>
+      <div className="action-section">
         <div className="demo-page-header">
-        <h2 className="demo-title">Account Recovery</h2>
+          <h2 className="demo-title">Account Recovery</h2>
         </div>
-        <div className="action-text">
-          Recover accounts on any device where your passkeys are located
-          <br/>
-          • Passkeys can be synced on iCloud Keychain or Google Password Manager
-          <br/>
-          • Synced passkeys across devices can recover the same wallet
-        </div>
-        <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
-          <LoadingButton
-            onClick={onRecover}
-            loading={busy}
-            loadingText="Recovering..."
-            variant="primary"
-            size="medium"
-            style={{ width: 200 }}
-          >
-            Start Recovery
-          </LoadingButton>
+
+        <SetupEmailRecovery />
+
+        <div style={{
+          marginTop: '2rem',
+          paddingTop: '2rem',
+          borderTop: '1px solid var(--fe-border)'
+        }}>
+          <h2 className="demo-title">Account Syncing</h2>
+          <div className="action-text">
+            Recover accounts on any device where your passkeys are synced,
+            such as iCloud Keychain or Google Password Manager.
+          </div>
+          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
+            <LoadingButton
+              onClick={onRecover}
+              loading={busy}
+              loadingText="Recovering..."
+              variant="primary"
+              size="medium"
+              style={{ width: 200 }}
+            >
+              Start Recovery
+            </LoadingButton>
+          </div>
         </div>
 
         <div style={{

--- a/examples/tatchi-docs/src/components/DemoPage.css
+++ b/examples/tatchi-docs/src/components/DemoPage.css
@@ -8,7 +8,7 @@
   font-size: 1.5rem;
   font-weight: 700;
   color: var(--fe-text);
-  margin: 0 0 var(--fe-gap-2) 0;
+  margin: 0;
 }
 
 .greeting-controls-box {

--- a/examples/tatchi-docs/src/components/DemoPage.tsx
+++ b/examples/tatchi-docs/src/components/DemoPage.tsx
@@ -509,7 +509,7 @@ export const DemoPage: React.FC = () => {
           </LoadingButton>
         </div>
       </div>
-      </div>
+    </div>
   );
 };
 

--- a/examples/tatchi-docs/src/components/EmailRecoveryFields.tsx
+++ b/examples/tatchi-docs/src/components/EmailRecoveryFields.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+
+export interface EmailRecoveryFieldsProps {
+  value?: string[];
+  onChange?: (emails: string[]) => void;
+  disabled?: boolean;
+  onChainHashes?: string[];
+  onClear?: () => void;
+}
+
+/**
+ * EmailRecoveryFields
+ * Simple controlled/uncontrolled list of email inputs with:
+ * - "+" button to add new fields
+ * - "×" button per field to remove it
+ */
+export const EmailRecoveryFields: React.FC<EmailRecoveryFieldsProps> = ({
+  value,
+  onChange,
+  disabled = false,
+  onChainHashes = [],
+  onClear,
+}) => {
+  const [internalEmails, setInternalEmails] = React.useState<string[]>(['']);
+
+  const emails = value ?? internalEmails;
+
+  const updateEmails = (next: string[]) => {
+    if (onChange) {
+      onChange(next);
+    }
+    if (value === undefined) {
+      setInternalEmails(next);
+    }
+  };
+
+  const handleAdd = () => {
+    if (disabled) return;
+    updateEmails([...emails, '']);
+  };
+
+  const handleChange = (index: number, nextValue: string) => {
+    const next = emails.slice();
+    next[index] = nextValue;
+    updateEmails(next);
+  };
+
+  const handleRemove = (index: number) => {
+    if (disabled) return;
+    if (emails.length === 1) {
+      // Keep at least one empty field for UX
+      updateEmails(['']);
+      return;
+    }
+    const next = emails.filter((_, i) => i !== index);
+    updateEmails(next);
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {emails.map((email, idx) => (
+        <div
+          key={idx}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          <input
+            type="email"
+            value={email}
+            disabled={disabled}
+            onChange={e => handleChange(idx, e.target.value)}
+            placeholder="recovery@example.com"
+            style={{
+              flex: 1,
+              padding: '0.4rem 0.75rem',
+              borderRadius: 9999,
+              border: '1px solid rgba(255,255,255,0.12)',
+              background: 'rgba(11,15,25,0.85)',
+              color: 'inherit',
+              outline: 'none',
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => handleRemove(idx)}
+            disabled={disabled}
+            aria-label="Remove email"
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 9999,
+              border: '1px solid rgba(255,255,255,0.18)',
+              background: 'transparent',
+              color: 'inherit',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: disabled ? 'default' : 'pointer',
+            }}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <button
+          type="button"
+          onClick={handleAdd}
+          disabled={disabled}
+          aria-label="Add recovery email"
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.18)',
+            background: 'transparent',
+            color: 'inherit',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: disabled ? 'default' : 'pointer',
+          }}
+        >
+          +
+        </button>
+        {onClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            disabled={disabled}
+            aria-label="Clear recovery emails"
+            style={{
+              padding: '0.25rem 0.75rem',
+              borderRadius: 9999,
+              border: '1px solid rgba(239,68,68,0.8)',
+              background: 'rgba(127,29,29,0.2)',
+              color: 'rgb(248,113,113)',
+              fontSize: 12,
+              cursor: disabled ? 'default' : 'pointer',
+            }}
+          >
+            Clear emails
+          </button>
+        )}
+      </div>
+      {onChainHashes.length > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <div style={{ fontSize: 12, opacity: 0.85 }}>On-chain recovery hashes</div>
+          <ul style={{ margin: 4, paddingLeft: 16, fontSize: 11 }}>
+            {onChainHashes.map((hash, idx) => (
+              <li
+                key={idx}
+                style={{
+                  fontFamily: 'monospace',
+                  wordBreak: 'break-all',
+                  opacity: 0.9,
+                }}
+              >
+                {hash}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EmailRecoveryFields;

--- a/examples/tatchi-docs/src/components/SetupEmailRecovery.tsx
+++ b/examples/tatchi-docs/src/components/SetupEmailRecovery.tsx
@@ -1,0 +1,405 @@
+import React from 'react';
+import { toast } from 'sonner';
+
+import {
+  ActionType,
+  TxExecutionStatus,
+  useTatchi,
+} from '@tatchi-xyz/sdk/react';
+
+import type { ActionArgs, ActionResult } from '@tatchi-xyz/sdk/react';
+import { LoadingButton } from './LoadingButton';
+import EmailRecoveryFields from './EmailRecoveryFields';
+import { NEAR_EXPLORER_BASE_URL } from '../types';
+
+const EMAIL_RECOVERER_CODE_ACCOUNT_ID = 'w3a-email-recoverer.testnet';
+const ZK_EMAIL_VERIFIER_ACCOUNT_ID = 'zk-email-verifier-v1.testnet';
+const EMAIL_DKIM_VERIFIER_ACCOUNT_ID = 'email-dkim-verifier-v1.testnet';
+
+async function hashRecoveryEmails(emails: string[], accountId: string): Promise<number[][]> {
+  const encoder = new TextEncoder();
+  const salt = (accountId || '').trim().toLowerCase();
+  const normalized = (emails || [])
+    .map(e => e.trim())
+    .filter(e => e.length > 0);
+
+  const hashed: number[][] = [];
+
+  for (const email of normalized) {
+    try {
+      // Canonicalize email:
+      // - Optional display name "Name <local@domain>" → "local@domain"
+      // - Trim spaces
+      // - Lowercase full address
+      let addr = email;
+      const angleStart = email.indexOf('<');
+      const angleEnd = email.indexOf('>');
+      if (angleStart !== -1 && angleEnd > angleStart) {
+        addr = email.slice(angleStart + 1, angleEnd);
+      }
+      const canonicalEmail = addr.trim().toLowerCase();
+
+      // hashed_email = SHA256(canonical_email || "|" || account_id)
+      const input = `${canonicalEmail}|${salt}`;
+      const data = encoder.encode(input);
+      const digest = await crypto.subtle.digest('SHA-256', data);
+      const bytes = new Uint8Array(digest);
+      hashed.push(Array.from(bytes));
+    } catch {
+      // Fallback: use raw UTF-8 bytes if hashing fails
+      const bytes = encoder.encode(email.toLowerCase());
+      hashed.push(Array.from(bytes));
+    }
+  }
+
+  return hashed;
+}
+
+export const SetupEmailRecovery: React.FC = () => {
+  const {
+    loginState: { isLoggedIn, nearAccountId },
+    tatchi,
+  } = useTatchi();
+
+  const [isBusy, setIsBusy] = React.useState(false);
+  const [recoveryEmails, setRecoveryEmails] = React.useState<string[]>(['']);
+  const [minRequiredEmails, setMinRequiredEmails] = React.useState<string>('1');
+  const [maxAgeMinutes, setMaxAgeMinutes] = React.useState<string>('30');
+
+  if (!isLoggedIn || !nearAccountId) {
+    return null;
+  }
+
+  const ensureTestnet = () => {
+    if (tatchi.configs.nearNetwork !== 'testnet') {
+      toast.error('Email recovery demo is only available on testnet for now.');
+      return false;
+    }
+    return true;
+  };
+
+  const handleDeleteEmailRecovery = async () => {
+    if (!tatchi || !nearAccountId) return;
+
+    if (!ensureTestnet()) return;
+
+    const toastId = 'email-recovery-delete';
+    setIsBusy(true);
+
+    try {
+      toast.loading('Disabling email recovery (clearing emails)...', { id: toastId });
+
+      const result = await tatchi.executeAction({
+        nearAccountId,
+        receiverId: nearAccountId,
+        actionArgs: [
+          {
+            type: ActionType.FunctionCall,
+            methodName: 'set_recovery_emails',
+            args: {
+              recovery_emails: [] as number[][],
+            },
+            gas: '80000000000000',
+            deposit: '0',
+          },
+        ],
+        options: {
+          waitUntil: TxExecutionStatus.EXECUTED_OPTIMISTIC,
+          afterCall: (success: boolean, actionResult?: ActionResult) => {
+            try {
+              toast.dismiss(toastId);
+            } catch {}
+
+            const txId = actionResult?.transactionId;
+
+            if (success && txId) {
+              const txLink = `${NEAR_EXPLORER_BASE_URL}/transactions/${txId}`;
+              toast.success('Email recovery disabled for this account', {
+                description: (
+                  <a href={txLink} target="_blank" rel="noopener noreferrer">
+                    View transaction on NearBlocks
+                  </a>
+                ),
+              });
+            } else if (success) {
+              toast.success('Email recovery disabled for this account');
+            } else {
+              const message = actionResult?.error || 'Failed to disable email recovery';
+              toast.error(message);
+            }
+          },
+        },
+      });
+
+      if (!result?.success) {
+        toast.error(result?.error || 'Failed to disable email recovery');
+      }
+    } catch (error: any) {
+      try {
+        toast.dismiss(toastId);
+      } catch {}
+      const message = error?.message || 'Failed to disable email recovery';
+      toast.error(message);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleSetRecoveryEmails = async () => {
+    if (!tatchi || !nearAccountId) return;
+    if (!ensureTestnet()) return;
+
+    const toastId = 'email-recovery-set-emails';
+    setIsBusy(true);
+
+    try {
+      toast.loading('Updating recovery emails...', { id: toastId });
+      const recoveryEmailHashes = await hashRecoveryEmails(recoveryEmails, nearAccountId);
+
+      // Detect whether the per-account EmailRecoverer contract is already deployed:
+      // - If code exists on this account, assume recoverer is present and just call set_recovery_emails.
+      // - If no code is present, attach the global email-recoverer and call new(...) with emails.
+      let hasContract = false;
+      try {
+        const nearClient = tatchi.getNearClient();
+        const code = await nearClient.viewCode(nearAccountId);
+        hasContract = !!code && code.byteLength > 0;
+      } catch {
+        hasContract = false;
+      }
+
+      const actions: ActionArgs[] = hasContract
+        ? [
+            {
+              type: ActionType.FunctionCall,
+              methodName: 'set_recovery_emails',
+              args: {
+                recovery_emails: recoveryEmailHashes,
+              },
+              gas: '80000000000000',
+              deposit: '0',
+            },
+          ]
+        : [
+            {
+              type: ActionType.UseGlobalContract,
+              accountId: EMAIL_RECOVERER_CODE_ACCOUNT_ID,
+            },
+            {
+              type: ActionType.FunctionCall,
+              methodName: 'new',
+              args: {
+                zk_email_verifier: ZK_EMAIL_VERIFIER_ACCOUNT_ID,
+                email_dkim_verifier: EMAIL_DKIM_VERIFIER_ACCOUNT_ID,
+                policy: null,
+                recovery_emails: recoveryEmailHashes,
+              },
+              gas: '80000000000000',
+              deposit: '0',
+            },
+          ];
+
+      const result = await tatchi.executeAction({
+        nearAccountId,
+        receiverId: nearAccountId,
+        actionArgs: actions,
+        options: {
+          waitUntil: TxExecutionStatus.EXECUTED_OPTIMISTIC,
+          afterCall: (success: boolean, actionResult?: ActionResult) => {
+            try {
+              toast.dismiss(toastId);
+            } catch {}
+
+            const txId = actionResult?.transactionId;
+
+            if (success && txId) {
+              const txLink = `${NEAR_EXPLORER_BASE_URL}/transactions/${txId}`;
+              toast.success('Recovery emails updated', {
+                description: (
+                  <a href={txLink} target="_blank" rel="noopener noreferrer">
+                    View transaction on NearBlocks
+                  </a>
+                ),
+              });
+            } else if (success) {
+              toast.success('Recovery emails updated');
+            } else {
+              const message = actionResult?.error || 'Failed to update recovery emails';
+              toast.error(message);
+            }
+          },
+        },
+      });
+
+      if (!result?.success) {
+        toast.error(result?.error || 'Failed to update recovery emails');
+      }
+    } catch (error: any) {
+      try {
+        toast.dismiss(toastId);
+      } catch {}
+      const message = error?.message || 'Failed to update recovery emails';
+      toast.error(message);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleSetRecoveryPolicy = async () => {
+    if (!tatchi || !nearAccountId) return;
+    if (!ensureTestnet()) return;
+
+    const toastId = 'email-recovery-set-policy';
+    setIsBusy(true);
+
+    try {
+      toast.loading('Updating recovery policy...', { id: toastId });
+
+      const minRequired = Math.max(1, parseInt(minRequiredEmails || '1', 10) || 1);
+      const maxAgeMins = Math.max(1, parseInt(maxAgeMinutes || '30', 10) || 30);
+      const max_age_ms = maxAgeMins * 60_000;
+
+      const actions: ActionArgs[] = [
+        {
+          type: ActionType.FunctionCall,
+          methodName: 'set_policy',
+          args: {
+            policy: {
+              min_required_emails: minRequired,
+              max_age_ms,
+            },
+          },
+          gas: '80000000000000',
+          deposit: '0',
+        },
+      ];
+
+      const result = await tatchi.executeAction({
+        nearAccountId,
+        receiverId: nearAccountId,
+        actionArgs: actions,
+        options: {
+          waitUntil: TxExecutionStatus.EXECUTED_OPTIMISTIC,
+          afterCall: (success: boolean, actionResult?: ActionResult) => {
+            try {
+              toast.dismiss(toastId);
+            } catch {}
+
+            const txId = actionResult?.transactionId;
+
+            if (success && txId) {
+              const txLink = `${NEAR_EXPLORER_BASE_URL}/transactions/${txId}`;
+              toast.success('Recovery policy updated', {
+                description: (
+                  <a href={txLink} target="_blank" rel="noopener noreferrer">
+                    View transaction on NearBlocks
+                  </a>
+                ),
+              });
+            } else if (success) {
+              toast.success('Recovery policy updated');
+            } else {
+              const message = actionResult?.error || 'Failed to update recovery policy';
+              toast.error(message);
+            }
+          },
+        },
+      });
+
+      if (!result?.success) {
+        toast.error(result?.error || 'Failed to update recovery policy');
+      }
+    } catch (error: any) {
+      try {
+        toast.dismiss(toastId);
+      } catch {}
+      const message = error?.message || 'Failed to update recovery policy';
+      toast.error(message);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <h2 className="demo-subtitle">Email Recovery (beta)</h2>
+      <div className="action-text">
+        Deploy a per-account recovery contract that can verify zk-email proofs
+        for secure, email-based wallet recovery.
+      </div>
+      <div style={{ marginTop: '0.75rem', maxWidth: 480 }}>
+        <EmailRecoveryFields
+          value={recoveryEmails}
+          onChange={setRecoveryEmails}
+          disabled={isBusy}
+          onClear={handleDeleteEmailRecovery}
+        />
+        <div style={{ marginTop: '0.5rem' }}>
+          <LoadingButton
+            onClick={handleSetRecoveryEmails}
+            loading={isBusy}
+            loadingText="Saving..."
+            variant="secondary"
+            size="small"
+            style={{ minWidth: 180 }}
+          >
+            Set Recovery Emails
+          </LoadingButton>
+        </div>
+      </div>
+      <div style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: 8, maxWidth: 480 }}>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+          <span style={{ fontSize: 13, opacity: 0.9 }}>Recovery policy</span>
+          <input
+            type="number"
+            min={1}
+            step={1}
+            value={minRequiredEmails}
+            onChange={e => setMinRequiredEmails(e.target.value)}
+            disabled={isBusy}
+            placeholder="Min required emails"
+            style={{
+              width: 80,
+              padding: '0.25rem 0.5rem',
+              borderRadius: 9999,
+              border: '1px solid rgba(255,255,255,0.16)',
+              background: 'rgba(11,15,25,0.85)',
+              color: 'inherit',
+            }}
+          />
+          <span style={{ fontSize: 12, opacity: 0.8 }}>Email</span>
+          <input
+            type="number"
+            min={1}
+            step={1}
+            value={maxAgeMinutes}
+            onChange={e => setMaxAgeMinutes(e.target.value)}
+            disabled={isBusy}
+            placeholder="Max age (minutes)"
+            style={{
+              width: 120,
+              padding: '0.25rem 0.5rem',
+              borderRadius: 9999,
+              border: '1px solid rgba(255,255,255,0.16)',
+              background: 'rgba(11,15,25,0.85)',
+              color: 'inherit',
+            }}
+          />
+          <span style={{ fontSize: 12, opacity: 0.8 }}>min timeout</span>
+          <LoadingButton
+            onClick={handleSetRecoveryPolicy}
+            loading={isBusy}
+            loadingText="Saving..."
+            variant="secondary"
+            size="small"
+            style={{ minWidth: 140 }}
+          >
+            Set Policy
+          </LoadingButton>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default SetupEmailRecovery;

--- a/examples/tatchi-docs/src/components/ToasterThemed.tsx
+++ b/examples/tatchi-docs/src/components/ToasterThemed.tsx
@@ -18,6 +18,7 @@ export const ToasterThemed: React.FC = () => {
         },
         // Keep error toasts (e.g., registration failures) visible
         // until the user explicitly closes them.
+        // @ts-ignore
         error: {
           duration: Infinity,
         },

--- a/examples/tatchi-docs/src/layout.css
+++ b/examples/tatchi-docs/src/layout.css
@@ -356,7 +356,13 @@
   background-color: var(--w3a-colors-surface);
   padding: 1rem;
   width: 200%;
-  margin-left: -225%;
+  margin-left: -230%;
+}
+
+@media (max-width: 1200px) {
+  .hero-ctas .cta-primary {
+    margin-left: -220%;
+  }
 }
 @media (max-width: 600px) {
   .hero-ctas {
@@ -365,7 +371,7 @@
   }
   .hero-ctas .cta-primary {
     margin-left: -1rem;
-    width: 190px;
+    width: 220px;
     margin-left: 0%;
   }
 }
@@ -385,14 +391,19 @@
   background-color: var(--w3a-colors-surface2);
   padding: 1rem;
   width: 200%;
-  margin-left: -200%;
+  margin-left: -205%;
+}
+@media (max-width: 1200px) {
+  .hero-ctas .cta-secondary {
+    margin-left: -195%;
+  }
 }
 @media (max-width: 600px) {
   .hero-ctas {
     align-items: flex-start;
   }
   .hero-ctas .cta-secondary {
-    width: 260px;
+    width: 290px;
     margin-left: 0;
   }
 }

--- a/examples/zk-email-cloudflare-worker/src/email-worker.ts
+++ b/examples/zk-email-cloudflare-worker/src/email-worker.ts
@@ -1,0 +1,69 @@
+type ForwardableEmailPayload = {
+  from: string;
+  to: string;
+  headers: Record<string, string>;
+  raw?: string;
+  rawSize?: number;
+};
+
+export default {
+  async email(message: any, env: any, ctx: any): Promise<void> {
+    const relayerUrl = env.RELAYER_URL ?? 'https://relay.tatchi.xyz';
+
+    // Hit the relay health endpoint once for basic liveness.
+    const healthResponse = await fetch(`${relayerUrl}/healthz`);
+    const relayerHealth = JSON.stringify(await healthResponse.json());
+
+    console.log('message.from:', JSON.stringify(message.from));
+    console.log('message.to:', JSON.stringify(message.to));
+
+    // Convert Headers to a standard JS object
+    const headersObj = Object.fromEntries(message.headers as any);
+    console.log('message.headers:', JSON.stringify(headersObj, null, 2));
+    console.log('DKIM-Signature:', message.headers.get('DKIM-Signature'));
+
+    const rawText = await new Response(message.raw).text();
+    console.log('message.raw:', rawText);
+    console.log('message.rawSize:', JSON.stringify(message.rawSize));
+
+    console.log('env:', JSON.stringify(env));
+    console.log('ctx:', JSON.stringify(ctx));
+
+    switch (message.to) {
+      case 'reset@web3authn.org': {
+        console.log(`Forwarding ZK-email reset request to ${relayerUrl}/reset-email`);
+
+        // Normalize headers to lowercase keys for the payload.
+        const normalizedHeaders: Record<string, string> = {};
+        for (const [k, v] of Object.entries(headersObj)) {
+          normalizedHeaders[String(k).toLowerCase()] = String(v);
+        }
+
+        const payload: ForwardableEmailPayload = {
+          from: message.from,
+          to: message.to,
+          headers: normalizedHeaders,
+          raw: rawText,
+          rawSize: typeof message.rawSize === 'number' ? message.rawSize : undefined,
+        };
+
+        const response = await fetch(`${relayerUrl}/reset-email`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          message.setReject('Recovery relayer rejected email');
+          return;
+        }
+
+        await message.forward('dev@web3authn.org');
+        break;
+      }
+
+      default:
+        message.setReject('Unknown address');
+    }
+  },
+};

--- a/examples/zk-email-cloudflare-worker/wrangler.toml
+++ b/examples/zk-email-cloudflare-worker/wrangler.toml
@@ -1,0 +1,4 @@
+name = "zk-email-cloudflare-worker"
+main = "src/email-worker.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["email"]

--- a/sdk/src/__tests__/lit-components/button-with-tooltip.test.ts
+++ b/sdk/src/__tests__/lit-components/button-with-tooltip.test.ts
@@ -19,7 +19,7 @@ test.describe('Lit component – button-with-tooltip', () => {
         nearAccountId: 'demo.testnet',
         txSigningRequests: [],
         tooltip: {
-          width: '340px',
+          width: '360px',
           height: 'auto',
           position: 'top-center',
           offset: '8px',

--- a/sdk/src/__tests__/unit/nearClient.test.ts
+++ b/sdk/src/__tests__/unit/nearClient.test.ts
@@ -1,0 +1,176 @@
+import { test, expect } from '@playwright/test';
+
+const IMPORT_PATHS = {
+  nearClient: '/sdk/esm/core/NearClient.js',
+} as const;
+
+test.describe('encodeSignedTransactionBase64', () => {
+  test.beforeEach(async ({ page }) => {
+    // Minimal bootstrap for pure unit tests: ensure origin is available for /sdk imports
+    await page.goto('/');
+  });
+
+  test('encodes SignedTransaction instances via methods', async ({ page }) => {
+    const res = await page.evaluate(async ({ paths }) => {
+      try {
+        const { SignedTransaction, encodeSignedTransactionBase64 } = await import(paths.nearClient);
+        const bytes = [0, 1, 2, 255];
+
+        const st = new SignedTransaction({
+          transaction: {} as any,
+          signature: {} as any,
+          borsh_bytes: bytes,
+        });
+
+        const encoded = encodeSignedTransactionBase64(st);
+
+        // Compute expected base64 in a simple, browser-safe way
+        let bin = '';
+        for (const b of bytes) bin += String.fromCharCode(b);
+        const expected = btoa(bin);
+
+        return { success: true, encoded, expected };
+      } catch (err: any) {
+        return { success: false, error: err?.message || String(err) };
+      }
+    }, { paths: IMPORT_PATHS });
+
+    if (!res.success) {
+      test.skip(true, `encodeSignedTransactionBase64 (methods) skipped: ${res.error || 'unknown error'}`);
+      return;
+    }
+
+    expect(res.encoded).toBe(res.expected);
+  });
+
+  test('encodes plain objects with borsh_bytes array', async ({ page }) => {
+    const res = await page.evaluate(async ({ paths }) => {
+      try {
+        const { encodeSignedTransactionBase64 } = await import(paths.nearClient);
+        const bytes = [10, 20, 30, 40];
+
+        const encoded = encodeSignedTransactionBase64({
+          transaction: {} as any,
+          signature: {} as any,
+          borsh_bytes: bytes,
+        });
+
+        let bin = '';
+        for (const b of bytes) bin += String.fromCharCode(b);
+        const expected = btoa(bin);
+
+        return { success: true, encoded, expected };
+      } catch (err: any) {
+        return { success: false, error: err?.message || String(err) };
+      }
+    }, { paths: IMPORT_PATHS });
+
+    if (!res.success) {
+      test.skip(true, `encodeSignedTransactionBase64 (borsh_bytes) skipped: ${res.error || 'unknown error'}`);
+      return;
+    }
+
+    expect(res.encoded).toBe(res.expected);
+  });
+
+  test('encodes plain objects with borshBytes typed array', async ({ page }) => {
+    const res = await page.evaluate(async ({ paths }) => {
+      try {
+        const { encodeSignedTransactionBase64 } = await import(paths.nearClient);
+        const bytes = new Uint8Array([5, 6, 7, 8]);
+
+        const encoded = encodeSignedTransactionBase64({
+          transaction: {} as any,
+          signature: {} as any,
+          borshBytes: bytes,
+        });
+
+        let bin = '';
+        for (const b of bytes) bin += String.fromCharCode(b);
+        const expected = btoa(bin);
+
+        return { success: true, encoded, expected };
+      } catch (err: any) {
+        return { success: false, error: err?.message || String(err) };
+      }
+    }, { paths: IMPORT_PATHS });
+
+    if (!res.success) {
+      test.skip(true, `encodeSignedTransactionBase64 (borshBytes) skipped: ${res.error || 'unknown error'}`);
+      return;
+    }
+
+    expect(res.encoded).toBe(res.expected);
+  });
+
+  test('throws on invalid payloads with no bytes', async ({ page }) => {
+    const res = await page.evaluate(async ({ paths }) => {
+      try {
+        const { encodeSignedTransactionBase64 } = await import(paths.nearClient);
+        let error: string | null = null;
+        try {
+          // Missing base64Encode/encode and no borsh_bytes / borshBytes
+          encodeSignedTransactionBase64({ transaction: {}, signature: {} } as any);
+        } catch (e: any) {
+          error = e?.message || String(e);
+        }
+        return { success: true, error };
+      } catch (err: any) {
+        return { success: false, error: err?.message || String(err) };
+      }
+    }, { paths: IMPORT_PATHS });
+
+    if (!res.success) {
+      test.skip(true, `encodeSignedTransactionBase64 (invalid payload) skipped: ${res.error || 'unknown error'}`);
+      return;
+    }
+
+    expect(res.error).toBe('Invalid signed transaction payload: cannot serialize to base64');
+  });
+
+  test('handles large borsh_bytes payloads without stack overflow', async ({ page }) => {
+    const res = await page.evaluate(async ({ paths }) => {
+      try {
+        const { SignedTransaction, encodeSignedTransactionBase64 } = await import(paths.nearClient);
+
+        const length = 100_000;
+        const bytes = new Array<number>(length);
+        for (let i = 0; i < length; i++) bytes[i] = i % 256;
+
+        const st = new SignedTransaction({
+          transaction: {} as any,
+          signature: {} as any,
+          borsh_bytes: bytes,
+        });
+
+        const encoded = encodeSignedTransactionBase64(st);
+
+        // Decode and verify a few sample positions
+        const bin = atob(encoded);
+        if (bin.length !== bytes.length) {
+          return { success: false, error: `Length mismatch: ${bin.length} != ${bytes.length}` };
+        }
+        const sampleIndices = [0, 1, 12345, length - 1];
+        for (const idx of sampleIndices) {
+          const expectedByte = bytes[idx];
+          const actualByte = bin.charCodeAt(idx);
+          if (expectedByte !== actualByte) {
+            return { success: false, error: `Byte mismatch at ${idx}: ${actualByte} != ${expectedByte}` };
+          }
+        }
+
+        return { success: true };
+      } catch (err: any) {
+        return { success: false, error: err?.message || String(err) };
+      }
+    }, { paths: IMPORT_PATHS });
+
+    if (!res.success) {
+      test.skip(true, `encodeSignedTransactionBase64 (large payload) skipped: ${res.error || 'unknown error'}`);
+      return;
+    }
+
+    expect(res.success).toBe(true);
+  });
+});
+

--- a/sdk/src/core/TatchiPasskey/actions.ts
+++ b/sdk/src/core/TatchiPasskey/actions.ts
@@ -224,6 +224,22 @@ export async function sendTransaction({
   let transactionResult;
   let txId;
   try {
+    // Debug snapshot of the signed transaction shape to aid integration debugging.
+    try {
+      const st: any = signedTransaction as any;
+      const snapshot = {
+        type: typeof st,
+        keys: st && typeof st === 'object' ? Object.keys(st) : null,
+        hasBase64Encode: typeof st?.base64Encode === 'function',
+        hasEncode: typeof st?.encode === 'function',
+        hasSnakeBytes: !!st?.borsh_bytes,
+        hasCamelBytes: !!st?.borshBytes,
+      };
+      console.debug('[sendTransaction] signedTransaction snapshot', snapshot);
+    } catch {
+      // best-effort logging only
+    }
+
     transactionResult = await context.nearClient.sendTransaction(
       signedTransaction,
       options?.waitUntil

--- a/sdk/src/core/TatchiPasskey/index.ts
+++ b/sdk/src/core/TatchiPasskey/index.ts
@@ -656,6 +656,34 @@ export class TatchiPasskey {
   }
 
   /**
+   * Convenience helper to sign and send a single transaction with actions.
+   * Internally delegates to signAndSendTransactions() and returns the first result.
+   */
+  async signAndSendTransaction({
+    nearAccountId,
+    receiverId,
+    actions,
+    options = {}
+  }: {
+    nearAccountId: string;
+    receiverId: string;
+    actions: ActionArgs[];
+    options?: SignAndSendTransactionHooksOptions;
+  }): Promise<ActionResult> {
+    const results = await this.signAndSendTransactions({
+      nearAccountId,
+      transactions: [
+        {
+          receiverId,
+          actions
+        }
+      ],
+      options
+    });
+    return results[0] as ActionResult;
+  }
+
+  /**
    * Batch sign transactions (with actions), allows you to sign transactions
    * to different receivers with a single TouchID prompt.
    * This method does not broadcast transactions, use sendTransaction() to do that.

--- a/sdk/src/core/WebAuthnManager/LitComponents/IframeTxConfirmer/tx-confirm-content.ts
+++ b/sdk/src/core/WebAuthnManager/LitComponents/IframeTxConfirmer/tx-confirm-content.ts
@@ -60,7 +60,7 @@ export class TxConfirmContentElement extends LitElementWithProps {
   // Keep essential custom elements from being tree-shaken
   private _ensureTreeDefinition = TxTree;
   // Tree width now sourced from a single CSS var so host can control it.
-  // Falls back to the embedded tooltip width, and then to 340px.
+  // Falls back to the embedded tooltip width, and then to 360px.
   private _txTreeWidth: string | number = 'var(--tooltip-width, 100%)';
 
   // No static styles: structural styles are provided by tx-confirmer.css

--- a/sdk/src/core/WebAuthnManager/LitComponents/IframeTxConfirmer/viewer-drawer.ts
+++ b/sdk/src/core/WebAuthnManager/LitComponents/IframeTxConfirmer/viewer-drawer.ts
@@ -264,7 +264,7 @@ export class DrawerTxConfirmerElement extends LitElementWithProps implements Con
               </div>
             </div>
           </div>
-          <div class="section responsive-card">
+          <div class="section responsive-card responsive-card-center">
             <w3a-tx-confirm-content
               .nearAccountId=${this.nearAccountId || ''}
               .txSigningRequests=${this.txSigningRequests || []}

--- a/sdk/src/core/WebAuthnManager/LitComponents/TxTree/tx-tree-utils.ts
+++ b/sdk/src/core/WebAuthnManager/LitComponents/TxTree/tx-tree-utils.ts
@@ -99,20 +99,63 @@ function buildActionNode(action: ActionArgs, idx: number): TreeNode {
       actionNodes = [];
       break;
 
-    case 'DeployContract':
+    case 'DeployContract': {
       const code = action.code;
+      const codeSize = formatCodeSize(code as any);
       actionNodes = [
         {
           id: `a${idx}-code-size`,
-          label: 'contract code:',
+          label: `WASM contract code size: ${codeSize}`,
           type: 'file',
           open: false,
-          hideChevron: true,
-          hideLabel: true, // hide "contract code:" row label
-          content: formatArgs(code.toString())
         }
       ];
       break;
+    }
+
+    case 'DeployGlobalContract': {
+      const code = action.code;
+      const deployMode = action.deployMode;
+      const codeSize = formatCodeSize(code as any);
+      actionNodes = [
+        {
+          id: `a${idx}-deploy-mode`,
+          label: `mode: ${deployMode}`,
+          type: 'file',
+          open: false,
+        },
+        {
+          id: `a${idx}-code-size`,
+          label: `WASM global contract code size: ${codeSize}`,
+          type: 'file',
+          open: false,
+        }
+      ];
+      break;
+    }
+
+    case 'UseGlobalContract': {
+      const accountId = action.accountId;
+      const codeHash = action.codeHash;
+      let label: string;
+      if (accountId) {
+        label = `by account: ${accountId}`;
+      } else if (codeHash) {
+        const short = shortenPubkey(codeHash, { prefix: 10, suffix: 6 });
+        label = `by hash: ${short}`;
+      } else {
+        label = 'by global contract identifier';
+      }
+      actionNodes = [
+        {
+          id: `a${idx}-identifier`,
+          label,
+          type: 'file',
+          open: false,
+        }
+      ];
+      break;
+    }
 
     case 'Stake':
       actionNodes = [

--- a/sdk/src/core/WebAuthnManager/LitComponents/common/tx-digest.ts
+++ b/sdk/src/core/WebAuthnManager/LitComponents/common/tx-digest.ts
@@ -57,6 +57,10 @@ export function orderActionForDigest(a: ActionArgsWasm) {
       return { action_type: a.action_type, beneficiary_id: a.beneficiary_id };
     case 'DeployContract':
       return { action_type: a.action_type, code: a.code };
+    case 'DeployGlobalContract':
+      return { action_type: a.action_type, code: a.code, deploy_mode: a.deploy_mode };
+    case 'UseGlobalContract':
+      return { action_type: a.action_type, account_id: a.account_id, code_hash: a.code_hash };
     case 'CreateAccount':
     default:
       return { action_type: a.action_type };

--- a/sdk/src/core/WebAuthnManager/LitComponents/css/drawer.css
+++ b/sdk/src/core/WebAuthnManager/LitComponents/css/drawer.css
@@ -8,8 +8,7 @@
 */
 
 w3a-drawer {
-  /* Size defaults */
-  --w3a-drawer__max-width: 375px;
+  --w3a-drawer__max-width: 384px; /* 360px toolTip width + 1.5rem (24px) */
   --w3a-drawer__sheet-height: 100dvh; /* prefer dynamic viewport */
   --w3a-drawer__open-offset: 0px;     /* mobile chrome compensation */
   /* Match TxTree row expand/collapse timing */
@@ -19,7 +18,7 @@ w3a-drawer {
 
 /* Duplicate token defaults for shadow-adopted usage */
 :host {
-  --w3a-drawer__max-width: var(--w3a-drawer__max-width, 375px);
+  --w3a-drawer__max-width: var(--w3a-drawer__max-width, 384px);
   --w3a-drawer__sheet-height: var(--w3a-drawer__sheet-height, 100dvh);
   --w3a-drawer__open-offset: var(--w3a-drawer__open-offset, 0px);
 }
@@ -59,7 +58,7 @@ w3a-drawer .drawer,
   box-shadow: 0 0px 8px rgba(0,0,0,0.2);
   padding: 0.5rem;
   /* Constrain width and center horizontally */
-  max-width: var(--w3a-drawer__max-width, 375px);
+  max-width: var(--w3a-drawer__max-width, 384px);
   margin-left: auto;
   margin-right: auto;
   /* Use a tall sheet so we can overpull without clipping */

--- a/sdk/src/core/WebAuthnManager/LitComponents/css/tx-confirmer.css
+++ b/sdk/src/core/WebAuthnManager/LitComponents/css/tx-confirmer.css
@@ -96,11 +96,11 @@ w3a-tx-confirm-content {
   touch-action: auto;
   width: fit-content;
   /* Responsive tooltip width that adapts to viewport and zoom */
-  --tooltip-margin: 1.25rem;
-  --tooltip-width: min(340px, calc(100vw - var(--tooltip-margin)));
+  --tooltip-margin: 1.5rem;
+  --tooltip-width: min(360px, calc(100vw - var(--tooltip-margin)));
 }
 @supports (width: 1dvw) {
-  .txc-root { --tooltip-width: min(340px, calc(100dvw - var(--tooltip-margin))); }
+  .txc-root { --tooltip-width: min(360px, calc(100dvw - var(--tooltip-margin))); }
 }
 .section { margin: 0.5rem 0; }
 .tooltip-width { width: var(--tooltip-width, 100%); }
@@ -750,6 +750,10 @@ w3a-drawer {
 }
 .margin-left1 {
   margin-left: 1rem;
+}
+.responsive-card-center {
+  display: flex;
+  justify-content: center;
 }
 
 .rpid-wrapper {

--- a/sdk/src/core/nonceManager.ts
+++ b/sdk/src/core/nonceManager.ts
@@ -282,13 +282,13 @@ export class NonceManager {
           const now = Date.now();
           if (fetchAccessKey) this.lastNonceUpdate = now;
           if (fetchBlock) this.lastBlockHeightUpdate = now;
-          console.debug('[NonceManager]: committed context', {
-            nextNonce: transactionContext.nextNonce,
-            txBlockHeight: transactionContext.txBlockHeight,
-            txBlockHash: transactionContext.txBlockHash,
-            lastNonceUpdate: this.lastNonceUpdate,
-            lastBlockHeightUpdate: this.lastBlockHeightUpdate,
-          });
+          // console.debug('[NonceManager]: committed context', {
+          //   nextNonce: transactionContext.nextNonce,
+          //   txBlockHeight: transactionContext.txBlockHeight,
+          //   txBlockHash: transactionContext.txBlockHash,
+          //   lastNonceUpdate: this.lastNonceUpdate,
+          //   lastBlockHeightUpdate: this.lastBlockHeightUpdate,
+          // });
         } else {
           // Discard results from outdated or identity-mismatched fetches; a newer fetch has already committed.
         }

--- a/sdk/src/server/core/AuthService.ts
+++ b/sdk/src/server/core/AuthService.ts
@@ -1041,6 +1041,125 @@ export class AuthService {
   }
 
   /**
+   * DKIM/TEE email recovery helper.
+   * Relayer signs a function call to the per-user email-recoverer contract
+   * deployed on `accountId`, passing the raw email blob for DKIM verification.
+   */
+  async recoverAccountFromEmailDKIMVerifier(request: { accountId: string; emailBlob: string }): Promise<{
+    success: boolean;
+    transactionHash?: string;
+    message?: string;
+    error?: string;
+  }> {
+    const accountId = (request.accountId || '').trim();
+    const emailBlob = request.emailBlob;
+
+    if (!this.isValidAccountId(accountId)) {
+      return {
+        success: false,
+        error: `Invalid account ID format: ${accountId}`,
+        message: `Invalid account ID format: ${accountId}`,
+      };
+    }
+    if (!emailBlob || typeof emailBlob !== 'string') {
+      return {
+        success: false,
+        error: 'emailBlob (raw email) is required',
+        message: 'emailBlob (raw email) is required',
+      };
+    }
+
+    await this._ensureSignerAndRelayerAccount();
+
+    return this.queueTransaction(async () => {
+      try {
+        // Prepare contract arguments for verify_dkim_and_recover(email_blob: String)
+        const contractArgs = {
+          email_blob: emailBlob,
+        };
+
+        const actions: ActionArgsWasm[] = [
+          {
+            action_type: ActionType.FunctionCall,
+            method_name: 'verify_dkim_and_recover',
+            args: JSON.stringify(contractArgs),
+            // Use generous gas similar to createAccountAndRegisterGas
+            gas: this.config.createAccountAndRegisterGas,
+            // Attach 0.01 NEAR as deposit for Outlayer/TEE DKIM verification (refunded minus fee).
+            // 0.01 NEAR = 10^22 yocto.
+            deposit: '10000000000000000000000',
+          },
+        ];
+        actions.forEach(validateActionArgsWasm);
+
+        const { nextNonce, blockHash } = await this.fetchTxContext(
+          this.config.relayerAccountId,
+          this.relayerPublicKey,
+        );
+
+        const signed = await this.signWithPrivateKey({
+          nearPrivateKey: this.config.relayerPrivateKey,
+          signerAccountId: this.config.relayerAccountId,
+          receiverId: accountId,
+          nonce: nextNonce,
+          blockHash,
+          actions,
+        });
+
+        const result = await this.nearClient.sendTransaction({ borshBytes: signed.borshBytes } as any);
+
+        const contractError = this.parseContractExecutionError(result, accountId);
+        if (contractError) {
+          console.error(`[AuthService] Email recovery contract error for ${accountId}:`, contractError);
+          return {
+            success: false,
+            error: contractError,
+            message: contractError,
+          };
+        }
+
+        console.log(`[AuthService] Email recovery flow completed for ${accountId}: ${result.transaction.hash}`);
+        return {
+          success: true,
+          transactionHash: result.transaction.hash,
+          message: `Email recovery flow executed for ${accountId}`,
+        };
+      } catch (error: any) {
+        const msg = error?.message || 'Unknown email recovery error';
+        console.error(`[AuthService] Email recovery failed for ${accountId}:`, msg);
+        return {
+          success: false,
+          error: msg,
+          message: msg,
+        };
+      }
+    }, `email recovery (dkim) for ${accountId}`);
+  }
+
+  /**
+   * ZK-email recovery helper (stub).
+   * Intended to call the global ZkEmailVerifier and per-user recovery contract
+   * once zk-email proofs and public inputs are wired through.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async recoverAccountFromZkEmailVerifier(_request: {
+    accountId: string;
+    proof: unknown;
+    publicInputs: unknown;
+  }): Promise<{
+    success: boolean;
+    transactionHash?: string;
+    message?: string;
+    error?: string;
+  }> {
+    return {
+      success: false,
+      error: 'recoverAccountFromZkEmailVerifier is not yet implemented',
+      message: 'recoverAccountFromZkEmailVerifier is not yet implemented',
+    };
+  }
+
+  /**
    * Express-style middleware factory for verify-authentication
    */
   verifyAuthenticationMiddleware() {

--- a/sdk/src/server/email-recovery/zkEmail.ts
+++ b/sdk/src/server/email-recovery/zkEmail.ts
@@ -1,0 +1,107 @@
+export interface ForwardableEmailPayload {
+  from: string;
+  to: string;
+  headers: Record<string, string>;
+  raw?: string;
+  rawSize?: number;
+}
+
+export type NormalizedEmailResult =
+  | { ok: true; payload: ForwardableEmailPayload }
+  | { ok: false; code: string; message: string };
+
+export function normalizeForwardableEmailPayload(input: unknown): NormalizedEmailResult {
+  if (!input || typeof input !== 'object') {
+    return { ok: false, code: 'invalid_email', message: 'JSON body required' };
+  }
+
+  const body = input as Partial<ForwardableEmailPayload>;
+  const { from, to, headers, raw, rawSize } = body;
+
+  if (!from || typeof from !== 'string' || !to || typeof to !== 'string') {
+    return { ok: false, code: 'invalid_email', message: 'from and to are required' };
+  }
+
+  if (!headers || typeof headers !== 'object') {
+    return { ok: false, code: 'invalid_email', message: 'headers object is required' };
+  }
+
+  const normalizedHeaders: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers as Record<string, unknown>)) {
+    normalizedHeaders[String(k).toLowerCase()] = String(v);
+  }
+
+  return {
+    ok: true,
+    payload: {
+      from,
+      to,
+      headers: normalizedHeaders,
+      raw: typeof raw === 'string' ? raw : undefined,
+      rawSize: typeof rawSize === 'number' ? rawSize : undefined,
+    },
+  };
+}
+
+/**
+ * Parse NEAR accountId from the Subject line inside a raw RFC822 email.
+ * Expected format (case-insensitive on "Subject"):
+ *   Subject: recover|bob.testnet|ed25519:xxxx...
+ *
+ * Returns the parsed accountId (e.g. "bob.testnet") or null if not found.
+ */
+export function parseAccountIdFromSubject(raw: string | undefined | null): string | null {
+  if (!raw || typeof raw !== 'string') return null;
+
+  // Accept either a full RFC822 message (with "Subject: ..." header)
+  // or a bare Subject value ("recover|bob.testnet|ed25519:...").
+  let subjectText = '';
+
+  const lines = raw.split(/\r?\n/);
+  const subjectLine = lines.find(line => /^subject:/i.test(line));
+  if (subjectLine) {
+    const [, restRaw = '' ] = subjectLine.split(/:/, 2);
+    subjectText = restRaw.trim();
+  } else {
+    subjectText = raw.trim();
+  }
+
+  if (!subjectText) return null;
+
+  // Expected "recover|accountId|ed25519:..."
+  const parts = subjectText.split('|').map(p => p.trim()).filter(Boolean);
+  if (parts.length < 2) return null;
+
+  // Be tolerant: if first token is "recover" (any case), treat the second as accountId.
+  if (/^recover$/i.test(parts[0]) && parts[1]) {
+    return parts[1];
+  }
+
+  // Otherwise, fall back to treating the first non-empty token as the accountId.
+  return parts[0] || null;
+}
+
+export async function generateZkEmailProofFromPayload(
+  payload: ForwardableEmailPayload
+): Promise<{ proof: unknown; publicInputs: unknown }> {
+  // TODO: Implement real ZK-email proof generation.
+  // Rough outline:
+  // 1) Normalize headers (lowercase keys, extract DKIM-Signature and other
+  //    security-relevant fields).
+  // 2) Parse the raw email (if provided) or reconstruct the body to extract:
+  //    - target NEAR account_id (e.g. "bob.near"),
+  //    - requested new_public_key,
+  //    - optional nonce/session binding or timestamp.
+  // 3) Build prover input for the zk-email circuit:
+  //    - include the raw RFC822 message or a structured representation
+  //      (headers + body + DKIM signature) expected by the circuit,
+  //    - include derived fields (account_id, new_public_key, nonce).
+  // 4) Call the external ZK prover (for example, Succinct's SP1 Prover
+  //    Network) with { program_id, input } and await { proof, public_inputs }.
+  // 5) Return proof + public_inputs so the caller can forward them on-chain
+  //    to the global ZkEmailVerifier and per-user recovery contracts.
+
+  // Stub implementation for now.
+  void payload;
+  return { proof: null, publicInputs: null };
+}

--- a/sdk/src/utils/base64.ts
+++ b/sdk/src/utils/base64.ts
@@ -1,13 +1,21 @@
 /**
  * Encodes an ArrayBuffer to standard base64 format for NEAR RPC compatibility.
  * Uses standard base64 characters (+, /, =) rather than base64url encoding.
- * Converts binary data to base64 string using browser's btoa() function.
+ *
+ * Important: Avoids spreading large arrays into String.fromCharCode(...) which
+ * can overflow the JS call stack when encoding big WASM binaries.
  *
  * @param value - ArrayBufferLike containing the binary data to encode
  * @returns Standard base64-encoded string with padding
  */
 export const base64Encode = (value: ArrayBufferLike): string => {
-  return btoa(String.fromCharCode(...Array.from(new Uint8Array(value as ArrayBufferLike))));
+  const bytes = new Uint8Array(value as ArrayBufferLike);
+  let binary = '';
+  // Build the string incrementally to avoid exceeding the argument limit.
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
 }
 
 /**

--- a/sdk/src/wasm_signer_worker/src/config.rs
+++ b/sdk/src/wasm_signer_worker/src/config.rs
@@ -3,7 +3,7 @@
 
 /// Change this constant and recompile to adjust logging verbosity
 /// Available levels: Error, Warn, Info, Debug, Trace
-pub const CURRENT_LOG_LEVEL: log::Level = log::Level::Info;
+pub const CURRENT_LOG_LEVEL: log::Level = log::Level::Debug;
 
 // === CRYPTOGRAPHIC CONSTANTS ===
 

--- a/sdk/src/wasm_signer_worker/src/handlers/confirm_tx_details.rs
+++ b/sdk/src/wasm_signer_worker/src/handlers/confirm_tx_details.rs
@@ -143,6 +143,7 @@ pub fn create_transaction_summary_from_parsed(
             match action {
                 ActionParams::CreateAccount => {}
                 ActionParams::DeployContract { .. } => {}
+                ActionParams::DeployGlobalContract { .. } => {}
                 ActionParams::FunctionCall { deposit, .. } => {
                     total_deposit += deposit.parse::<u128>().unwrap_or(0);
                 }
@@ -155,6 +156,7 @@ pub fn create_transaction_summary_from_parsed(
                 ActionParams::AddKey { .. } => {}
                 ActionParams::DeleteKey { .. } => {}
                 ActionParams::DeleteAccount { .. } => {}
+                ActionParams::UseGlobalContract { .. } => {}
             }
         }
     }

--- a/sdk/src/wasm_signer_worker/src/types/near.rs
+++ b/sdk/src/wasm_signer_worker/src/types/near.rs
@@ -93,6 +93,22 @@ pub type Nonce = u64;
 pub type Gas = u64;
 pub type Balance = u128;
 
+// === NEP-0591 GLOBAL CONTRACT TYPES ===
+
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GlobalContractDeployMode {
+    CodeHash,
+    AccountId,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GlobalContractIdentifier {
+    CodeHash(CryptoHash),   // 32-byte code hash
+    AccountId(AccountId),   // owner account ID
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FunctionCallAction {
@@ -128,6 +144,15 @@ pub enum Action {
     },
     DeleteAccount {
         beneficiary_id: AccountId,
+    },
+    SignedDelegate,
+    DeployGlobalContract {
+        #[serde(with = "serde_bytes")]
+        code: Vec<u8>,
+        deploy_mode: GlobalContractDeployMode,
+    },
+    UseGlobalContract {
+        contract_identifier: GlobalContractIdentifier,
     },
 }
 


### PR DESCRIPTION
# Summary

1. Wire DKIM/TEE email recovery flow end‑to‑end:
  - Add AuthService.recoverAccountFromEmailDKIMVerifier to call per‑account email-recoverer with verify_dkim_and_recover(email_blob), attaching 0.01 NEAR for Outlayer/TEE execution.
  - Expose POST /reset-email on both Express and Cloudflare relay adaptors to accept ForwardableEmailPayload, parse accountId from Subject/headers, and invoke the DKIM recover helper.

2. Add zk‑email Cloudflare email worker that:
- Receives reset@web3authn.org emails via Email Routing.
- Normalizes headers + raw body into ForwardableEmailPayload.
- Forwards to ${RELAYER_URL}/reset-email, and forwards the email to dev@web3authn.org on success.

3. Integrate deployment and configuration
- Add deploy-zk-email-cloudflare-worker.yml workflow to deploy the email worker and configure the Email Routing rule for reset@web3authn.org.
